### PR TITLE
JSON-LD Knowledge Object - work in progress

### DIFF
--- a/activator/pom.xml
+++ b/activator/pom.xml
@@ -56,10 +56,6 @@
 					<artifactId>httpclient</artifactId>
 					<groupId>org.apache.httpcomponents</groupId>
 				</exclusion>
-				<exclusion>
-					<artifactId>httpclient-cache</artifactId>
-					<groupId>org.apache.httpcomponents</groupId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/activator/src/main/java/AppConfig.java
+++ b/activator/src/main/java/AppConfig.java
@@ -1,0 +1,21 @@
+import edu.umich.lhs.activator.services.KobjectConverter;
+import java.util.List;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+/**
+ * Created by grosscol on 2018-01-10.
+ */
+
+
+@ComponentScan
+public class AppConfig extends WebMvcConfigurerAdapter {
+
+  @Override
+  public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+    converters.add(new KobjectConverter());
+  }
+}

--- a/activator/src/main/java/edu/umich/lhs/activator/controller/ShelfController.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/controller/ShelfController.java
@@ -93,6 +93,9 @@ public class ShelfController {
         if (payload.getContent() == null) {
             throw new ActivatorException("Content is null for object with Ark Id:  " + arkId);
         }
+        else if(payload.getContent().isEmpty()){
+            throw new ActivatorException("Content is empty for object with Ark Id:  " + arkId);
+        }
         return payload.getContent();
 
     }

--- a/activator/src/main/java/edu/umich/lhs/activator/controller/ShelfController.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/controller/ShelfController.java
@@ -1,7 +1,7 @@
 package edu.umich.lhs.activator.controller;
 
 import edu.umich.lhs.activator.domain.KnowledgeObject;
-import edu.umich.lhs.activator.domain.KnowledgeObject.Payload;
+import edu.umich.lhs.activator.domain.Payload;
 import edu.umich.lhs.activator.exception.ActivatorException;
 import edu.umich.lhs.activator.repository.RemoteShelf;
 import edu.umich.lhs.activator.repository.Shelf;

--- a/activator/src/main/java/edu/umich/lhs/activator/controller/ShelfController.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/controller/ShelfController.java
@@ -1,11 +1,11 @@
 package edu.umich.lhs.activator.controller;
 
 import edu.umich.lhs.activator.domain.KnowledgeObject;
+import edu.umich.lhs.activator.domain.Kobject;
 import edu.umich.lhs.activator.domain.Payload;
 import edu.umich.lhs.activator.exception.ActivatorException;
 import edu.umich.lhs.activator.repository.RemoteShelf;
 import edu.umich.lhs.activator.repository.Shelf;
-import edu.umich.lhs.activator.repository.Shelf.SourcedKO;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,30 +41,28 @@ public class ShelfController {
         ResponseEntity<String> result;
         String response = "Object " + arkId.getArkId() + " added to the shelf";
 
-        KnowledgeObject dto = libraryInterface.checkOutByArkId(arkId);
+        Kobject kob = libraryInterface.checkOutByArkId(arkId);
         if(localStorage.isBuiltinObject(arkId)) {
             response = "Object " + arkId.getArkId() + " added to the shelf, overriding existing built-in object.";
         }
-        localStorage.saveObject(dto, arkId);
+        localStorage.saveObject(kob, arkId);
 
         result = new ResponseEntity<>(response, HttpStatus.OK);
 
         return result;
-
     }
-
 
     @PutMapping(consumes = {MediaType.APPLICATION_JSON_VALUE},
             path = {"/knowledgeObject/ark:/{naan}/{name}", "/shelf/ark:/{naan}/{name}"})
-    public ResponseEntity<String> checkOutObject(ArkId arkId, @RequestBody KnowledgeObject dto) throws ActivatorException {
+    public ResponseEntity<String> checkOutObject(ArkId arkId, @RequestBody Kobject kob) throws ActivatorException {
         try {
             String response = "Object " + arkId.getArkId() + " added to the shelf";
             if(localStorage.isBuiltinObject(arkId)) {
                 response = "Object " + arkId.getArkId() + " added to the shelf, overriding existing built-in object.";
             }
-            dto.url = NAME_TO_THING_ADD + arkId;
-            localStorage.saveObject(dto, arkId);
-            ResponseEntity<String> result = new ResponseEntity<String>(response, HttpStatus.OK);
+            kob.setUrl(NAME_TO_THING_ADD + arkId);
+            localStorage.saveObject(kob, arkId);
+            ResponseEntity<String> result = new ResponseEntity<>(response, HttpStatus.OK);
             return result;
         } catch (Exception e) {
             throw new ActivatorException("Unable to save object with ArkId: " + arkId + ", root cause: " + e.getMessage(), e);
@@ -72,7 +70,7 @@ public class ShelfController {
     }
 
     @GetMapping(path = {"/knowledgeObject", "/shelf"})
-    public List<SourcedKO> retrieveObjectsOnShelf() {
+    public List<Kobject> retrieveObjectsOnShelf() {
         return localStorage.getAllObjects();
     }
 
@@ -102,15 +100,15 @@ public class ShelfController {
     @GetMapping(path = {"/knowledgeObject/ark:/{naan}/{name}/payload", "/shelf/ark:/{naan}/{name}/payload"})
     public Payload retrieveObjectPayload(ArkId arkId) {
 
-        KnowledgeObject dto = retrieveObjectOnShelf(arkId);
-        if (dto.payload == null) {
+        Kobject kob = retrieveObjectOnShelf(arkId);
+        if (kob.getPayload() == null) {
             throw new ActivatorException("Payload is null for object with Ark Id:  " + arkId);
         }
-        return dto.payload;
+        return kob.getPayload();
     }
 
     @GetMapping(path = {"/knowledgeObject/ark:/{naan}/{name}", "/shelf/ark:/{naan}/{name}"})
-    public KnowledgeObject retrieveObjectOnShelf(ArkId arkId) {
+    public Kobject retrieveObjectOnShelf(ArkId arkId) {
         return localStorage.getObject(arkId);
     }
 

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/KnowledgeObject.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/KnowledgeObject.java
@@ -26,9 +26,9 @@ public class KnowledgeObject {
 
 	public Payload genPayload(String content, String engineType, String functionName) {
 		this.payload = new Payload();
-		this.payload.content = content;
-		this.payload.engineType = engineType;
-		this.payload.functionName = functionName;
+		this.payload.setContent(content);
+		this.payload.setEngineType(engineType);
+		this.payload.setFunctionName(functionName);
 		return this.payload;
 	}
 	
@@ -38,48 +38,5 @@ public class KnowledgeObject {
 				+ payload + ", url=" + url + "]";
 	}
 
-	public class Payload {
-		
-		private String content;
-		
-		private String engineType;
-		
-		private String functionName;
 
-		public String getContent() {
-			return content;
-		}
-
-		public void setContent(String content) {
-			this.content = content;
-		}
-
-		public String getEngineType() {
-			return engineType.toUpperCase();
-		}
-
-		public void setEngineType(String engineType) {
-			this.engineType = engineType;
-		}
-
-		public String getFunctionName() {
-			return functionName;
-		}
-
-		public void setFunctionName(String functionName) {
-			this.functionName = functionName;
-		}
-
-		public Payload() {
-			// TODO Auto-generated constructor stub
-		}
-
-		@Override
-		public String toString() {
-			return "Payload [content=" + content + ", engineType=" + engineType + ", functionName=" + functionName
-					+ "]";
-		}
-
-
-	}
 }

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/Kobject.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/Kobject.java
@@ -1,0 +1,31 @@
+package edu.umich.lhs.activator.domain;
+
+import edu.umich.lhs.activator.domain.Payload;
+import java.util.ArrayList;
+import java.util.Map;
+
+/**
+ * Created by grosscol on 2017-09-11.
+ */
+public class Kobject implements PayloadProvider {
+
+  public Metadata metadata;
+  public Payload payload;
+
+  @Override
+  public Class getReturnType() {
+    return Map.class;
+  }
+
+  @Override
+  public int getNoOfParams() {
+    return 0;
+  }
+
+  @Override
+  public ArrayList<ParamDescription> getParams() {
+    return new ArrayList<>();
+  }
+
+
+}

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/Kobject.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/Kobject.java
@@ -27,5 +27,20 @@ public class Kobject implements PayloadProvider {
     return new ArrayList<>();
   }
 
+  @Override
+  public String getFunctionName() {
+    return "";
+  }
+
+  @Override
+  public String getContent() {
+    return "";
+  }
+
+  @Override
+  public String getEngineType() {
+    return "";
+  }
+
 
 }

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/Kobject.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/Kobject.java
@@ -1,7 +1,9 @@
 package edu.umich.lhs.activator.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Map;
+import org.apache.jena.rdf.model.Model;
 
 /**
  * Created by grosscol on 2017-09-11.
@@ -15,6 +17,34 @@ public class Kobject implements PayloadProvider {
   private ArrayList<ParamDescription> paramDescriptions;
   private Class returnType;
   private ArkId identifier;
+  private String url;
+
+
+  @JsonIgnore
+  private Model rdfModel;
+
+  public Kobject(){
+    paramDescriptions = new ArrayList<>();
+    payload = new Payload();
+    url = "";
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  @Override
+  public String toString() {
+    return "Kobject [FunctionName=" + payload.getFunctionName() +
+        ", engineType=" + payload.getEngineType() +
+        ", payloadContent=" + payload.getContent() +
+        ", url=" + url +
+        "]";
+  }
 
   @Override
   public Class getReturnType() {
@@ -37,17 +67,22 @@ public class Kobject implements PayloadProvider {
 
   @Override
   public String getFunctionName() {
-    return "";
+    return payload.getFunctionName();
   }
 
   @Override
   public String getContent() {
-    return "";
+    return payload.getContent();
   }
 
   @Override
   public String getEngineType() {
-    return "";
+    return payload.getEngineType();
+  }
+
+  //TODO: Refactor such that this is not required?  Use payload provider or suitable interface?
+  public Payload getPayload() {
+    return payload;
   }
 
   public ArkId getIdentifier() {
@@ -62,6 +97,10 @@ public class Kobject implements PayloadProvider {
     paramDescriptions = p;
   }
 
+  public void addParamDescriptions(ParamDescription p) {
+    paramDescriptions.add(p);
+  }
+
   public void setNoofParams(Integer i) {
     noofParams = i;
   }
@@ -70,5 +109,11 @@ public class Kobject implements PayloadProvider {
     payload = p;
   }
 
+  public Model getRdfModel() {
+    return rdfModel;
+  }
 
+  public void setRdfModel(Model rdfModel) {
+    this.rdfModel = rdfModel;
+  }
 }

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/Kobject.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/Kobject.java
@@ -10,7 +10,12 @@ import java.util.Map;
 public class Kobject implements PayloadProvider {
 
   public Metadata metadata;
-  public Payload payload;
+
+  private Payload payload;
+  private Integer noofParams;
+  private ArrayList<ParamDescription> paramDescriptions;
+  private Class returnType;
+  private ArkId identifier;
 
   @Override
   public Class getReturnType() {
@@ -41,6 +46,32 @@ public class Kobject implements PayloadProvider {
   public String getEngineType() {
     return "";
   }
+
+  public ArkId getIdentifier(){
+    return identifier;
+  }
+
+  public void setIdentifier(ArkId id){
+    identifier = id;
+  }
+
+  public void setParamDescriptions(ArrayList<ParamDescription> p){
+    paramDescriptions = p;
+  }
+
+  public void setNoofParams(Integer i){
+    noofParams = i;
+  }
+
+  public void setReturnType(Class c){
+    returnType = c;
+  }
+
+  public void setPayload(Payload p){
+    payload = p;
+  }
+
+
 
 
 }

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/Kobject.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/Kobject.java
@@ -1,6 +1,5 @@
 package edu.umich.lhs.activator.domain;
 
-import edu.umich.lhs.activator.domain.Payload;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -20,6 +19,10 @@ public class Kobject implements PayloadProvider {
   @Override
   public Class getReturnType() {
     return Map.class;
+  }
+
+  public void setReturnType(Class c) {
+    returnType = c;
   }
 
   @Override
@@ -47,31 +50,25 @@ public class Kobject implements PayloadProvider {
     return "";
   }
 
-  public ArkId getIdentifier(){
+  public ArkId getIdentifier() {
     return identifier;
   }
 
-  public void setIdentifier(ArkId id){
+  public void setIdentifier(ArkId id) {
     identifier = id;
   }
 
-  public void setParamDescriptions(ArrayList<ParamDescription> p){
+  public void setParamDescriptions(ArrayList<ParamDescription> p) {
     paramDescriptions = p;
   }
 
-  public void setNoofParams(Integer i){
+  public void setNoofParams(Integer i) {
     noofParams = i;
   }
 
-  public void setReturnType(Class c){
-    returnType = c;
-  }
-
-  public void setPayload(Payload p){
+  public void setPayload(Payload p) {
     payload = p;
   }
-
-
 
 
 }

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/Kobject.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/Kobject.java
@@ -27,6 +27,7 @@ public class Kobject implements PayloadProvider {
     paramDescriptions = new ArrayList<>();
     payload = new Payload();
     url = "";
+    returnType = Map.class;
   }
 
   public String getUrl() {
@@ -48,7 +49,7 @@ public class Kobject implements PayloadProvider {
 
   @Override
   public Class getReturnType() {
-    return Map.class;
+    return returnType;
   }
 
   public void setReturnType(Class c) {
@@ -57,12 +58,15 @@ public class Kobject implements PayloadProvider {
 
   @Override
   public int getNoOfParams() {
-    return 0;
+    if(noofParams == null){
+      return 0;
+    }
+    return noofParams;
   }
 
   @Override
   public ArrayList<ParamDescription> getParams() {
-    return new ArrayList<>();
+    return paramDescriptions;
   }
 
   @Override

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/ParamDescription.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/ParamDescription.java
@@ -1,62 +1,63 @@
 package edu.umich.lhs.activator.domain;
 
 public class ParamDescription {
-	
-	private String name;
-	
-	private DataType datatype;
-	
-	private Integer min;
-	
-	private Integer max;
 
-	public ParamDescription(){}
-	
-	public ParamDescription(String name, DataType datatype, Integer min, Integer max) {
-		super();
-		this.name = name;
-		this.datatype = datatype;
-		this.min = min;
-		this.max = max;
-	}
+  private String name;
 
-	public String getName() {
-		return name;
-	}
+  private DataType datatype;
 
-	public void setName(String name) {
-		this.name = name;
-	}
+  private Integer min;
 
-	public DataType getDatatype() {
-		return datatype;
-	}
+  private Integer max;
 
-	public void setDatatype(DataType datatype) {
-		this.datatype = datatype;
-	}
+  public ParamDescription() {
+  }
 
-	public Integer getMin() {
-		return min;
-	}
+  public ParamDescription(String name, DataType datatype, Integer min, Integer max) {
+    super();
+    this.name = name;
+    this.datatype = datatype;
+    this.min = min;
+    this.max = max;
+  }
 
-	public void setMin(Integer min) {
-		this.min = min;
-	}
+  public String getName() {
+    return name;
+  }
 
-	public Integer getMax() {
-		return max;
-	}
+  public void setName(String name) {
+    this.name = name;
+  }
 
-	public void setMax(Integer max) {
-		this.max = max;
-	}
+  public DataType getDatatype() {
+    return datatype;
+  }
 
-	@Override
-	public String toString() {
-		return "ParamDescription [name=" + name + ", datatype=" + datatype + ", min=" + min + ", max=" + max + "]";
-	}
-	
-	
+  public void setDatatype(DataType datatype) {
+    this.datatype = datatype;
+  }
+
+  public Integer getMin() {
+    return min;
+  }
+
+  public void setMin(Integer min) {
+    this.min = min;
+  }
+
+  public Integer getMax() {
+    return max;
+  }
+
+  public void setMax(Integer max) {
+    this.max = max;
+  }
+
+  @Override
+  public String toString() {
+    return "ParamDescription [name=" + name + ", datatype=" + datatype + ", min=" + min + ", max="
+        + max + "]";
+  }
+
 
 }

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/Payload.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/Payload.java
@@ -1,0 +1,49 @@
+package edu.umich.lhs.activator.domain;
+
+/**
+ * Extracted from KnoweledgeObject by grosscol on 2017-09-11.
+ */
+public class Payload {
+
+  private String content;
+
+  private String engineType;
+
+  private String functionName;
+
+  public String getContent() {
+    return content;
+  }
+
+  public void setContent(String content) {
+    this.content = content;
+  }
+
+  public String getEngineType() {
+    return engineType.toUpperCase();
+  }
+
+  public void setEngineType(String engineType) {
+    this.engineType = engineType;
+  }
+
+  public String getFunctionName() {
+    return functionName;
+  }
+
+  public void setFunctionName(String functionName) {
+    this.functionName = functionName;
+  }
+
+  public Payload() {
+    // TODO Auto-generated constructor stub
+  }
+
+  @Override
+  public String toString() {
+    return "Payload [content=" + content + ", engineType=" + engineType + ", functionName=" + functionName
+        + "]";
+  }
+
+
+}

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/Payload.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/Payload.java
@@ -17,6 +17,12 @@ public class Payload {
     functionName = "";
   }
 
+  public Payload(String content, String engineType, String functionName){
+    this.content = content;
+    this.engineType = engineType;
+    this.functionName = functionName;
+  }
+
   public String getContent() {
     return content;
   }

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/Payload.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/Payload.java
@@ -12,7 +12,9 @@ public class Payload {
   private String functionName;
 
   public Payload() {
-    // TODO Auto-generated constructor stub
+    content = "";
+    engineType = "NONE";
+    functionName = "";
   }
 
   public String getContent() {

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/Payload.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/Payload.java
@@ -11,6 +11,10 @@ public class Payload {
 
   private String functionName;
 
+  public Payload() {
+    // TODO Auto-generated constructor stub
+  }
+
   public String getContent() {
     return content;
   }
@@ -35,13 +39,10 @@ public class Payload {
     this.functionName = functionName;
   }
 
-  public Payload() {
-    // TODO Auto-generated constructor stub
-  }
-
   @Override
   public String toString() {
-    return "Payload [content=" + content + ", engineType=" + engineType + ", functionName=" + functionName
+    return "Payload [content=" + content + ", engineType=" + engineType + ", functionName="
+        + functionName
         + "]";
   }
 

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/PayloadProvider.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/PayloadProvider.java
@@ -1,0 +1,12 @@
+package edu.umich.lhs.activator.domain;
+
+import java.util.ArrayList;
+
+/**
+ * Created by grosscol on 2017-09-11.
+ */
+public interface PayloadProvider {
+  public Class getReturnType();
+  public int getNoOfParams();
+  public ArrayList<ParamDescription> getParams();
+}

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/PayloadProvider.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/PayloadProvider.java
@@ -6,10 +6,34 @@ import java.util.ArrayList;
  * Created by grosscol on 2017-09-11.
  */
 public interface PayloadProvider {
+
+  /**
+   * @return number of parameters of payload function
+   */
   public int getNoOfParams();
+
+  /**
+   * @return array of descriptions of parameters
+   */
   public ArrayList<ParamDescription> getParams();
+
+  /**
+   * @return name of the function in the payload for the activator to call
+   */
   public String getFunctionName();
+
+  /**
+   * @return content of the payload for the activator to execute or serve
+   */
   public String getContent();
+
+  /**
+   * @return name of the engine for the activator to match with an appropriate adapter
+   */
   public String getEngineType();
+
+  /**
+   * @return Java class that the result of the payload should be cast to.
+   */
   public Class getReturnType();
 }

--- a/activator/src/main/java/edu/umich/lhs/activator/domain/PayloadProvider.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/domain/PayloadProvider.java
@@ -6,7 +6,10 @@ import java.util.ArrayList;
  * Created by grosscol on 2017-09-11.
  */
 public interface PayloadProvider {
-  public Class getReturnType();
   public int getNoOfParams();
   public ArrayList<ParamDescription> getParams();
+  public String getFunctionName();
+  public String getContent();
+  public String getEngineType();
+  public Class getReturnType();
 }

--- a/activator/src/main/java/edu/umich/lhs/activator/repository/RemoteShelf.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/repository/RemoteShelf.java
@@ -3,15 +3,22 @@ package edu.umich.lhs.activator.repository;
 
 import edu.umich.lhs.activator.domain.ArkId;
 import edu.umich.lhs.activator.domain.KnowledgeObject;
+import edu.umich.lhs.activator.domain.Kobject;
 import edu.umich.lhs.activator.exception.ActivatorException;
 import edu.umich.lhs.activator.exception.BadGatewayException;
+import edu.umich.lhs.activator.services.KobjectImporter;
+import java.util.Collections;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
@@ -25,23 +32,28 @@ public class RemoteShelf {
 	
 	private final Logger log = LoggerFactory.getLogger(this.getClass());
 
-	public KnowledgeObject checkOutByArkId(ArkId arkId) throws ActivatorException {
+	public Kobject checkOutByArkId(ArkId arkId) throws ActivatorException {
 
-		KnowledgeObject object;
-		
+		Kobject kob;
+		String url = getAbsoluteObjectUrl(arkId) + "/complete";
+
 		try {
-
 			// This creates a client that redirects on gets for HTTP 3xx redirect responses.
 			HttpClient instance = HttpClientBuilder.create()
 					.setRedirectStrategy(new DefaultRedirectStrategy()).build();
 
 			RestTemplate rest = new RestTemplate(new HttpComponentsClientHttpRequestFactory(instance));
 
-			ResponseEntity<KnowledgeObject> response = rest.getForEntity(getAbsoluteObjectUrl(arkId) + "/complete", KnowledgeObject.class);
+			// Only accept JSON
+			HttpHeaders headers = new HttpHeaders();
+			headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
 
-			object = response.getBody() ; 
+			// Expect back a string of json
+			HttpEntity<String> entity = new HttpEntity<String>(headers);
+			ResponseEntity<String> response = rest.exchange(url, HttpMethod.GET, entity, String.class);
 
-			object.url = getAbsoluteObjectUrl(arkId) ; 
+			kob = KobjectImporter.jsonToKobject(response.getBody());
+			kob.setUrl(getAbsoluteObjectUrl(arkId));
 
 			log.info("KnowledgeObject with Ark Id: "+ arkId + "is checked out from : "+ getAbsoluteObjectUrl(arkId) );
 		} catch ( HttpClientErrorException e ) {
@@ -52,8 +64,7 @@ public class RemoteShelf {
 			}
 		}
 		
-		
-		return object;
+		return kob;
 	}
 
 	public boolean libraryObjectExists(ArkId arkId) {

--- a/activator/src/main/java/edu/umich/lhs/activator/services/ActivationService.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/ActivationService.java
@@ -3,7 +3,7 @@ package edu.umich.lhs.activator.services;
 import edu.umich.lhs.activator.adapter.EnvironmentAdapter;
 import edu.umich.lhs.activator.domain.ArkId;
 import edu.umich.lhs.activator.domain.KnowledgeObject;
-import edu.umich.lhs.activator.domain.KnowledgeObject.Payload;
+import edu.umich.lhs.activator.domain.Payload;
 import edu.umich.lhs.activator.domain.Result;
 import edu.umich.lhs.activator.exception.ActivatorException;
 import edu.umich.lhs.activator.repository.Shelf;

--- a/activator/src/main/java/edu/umich/lhs/activator/services/ActivationService.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/ActivationService.java
@@ -117,9 +117,18 @@ public class ActivationService implements ApplicationContextAware {
     log.info("Object Input Message and Output Message conversion complete . Code Metadata for Input and Output Message ");
     */
 
-    PayloadInputValidator validator = new PayloadInputValidator(kob, inputs);
+    PayloadProviderValidator pValidator = new PayloadProviderValidator(kob);
+    pValidator.verify();
 
-    if(validator.isValid()){
+    PayloadInputValidator inputValidator = new PayloadInputValidator(kob, inputs);
+
+
+    // Problem with the structure of the provided payload
+    if(!pValidator.verify()){
+      throw new ActivatorException(pValidator.getMessage());
+    }
+
+    if(inputValidator.isValid()){
       log.info("Payload provider (kobject) validataed.");
       log.info("Object payload is sent to Adapter for execution.");
 
@@ -137,6 +146,9 @@ public class ActivationService implements ApplicationContextAware {
       } catch (InvocationTargetException invocationEx) {
         throw new ActivatorException("Error invoking execute due to internal adapter error: " + invocationEx.getCause(), invocationEx);
       }
+    }
+    else{
+      throw new ActivatorException(inputValidator.getMessage());
     }
 
     return result;

--- a/activator/src/main/java/edu/umich/lhs/activator/services/KobjectConverter.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/KobjectConverter.java
@@ -1,0 +1,58 @@
+package edu.umich.lhs.activator.services;
+
+import edu.umich.lhs.activator.domain.Kobject;
+import java.io.IOException;
+import java.io.OutputStream;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.stereotype.Component;
+
+/**
+ * Created by grosscol on 2018-01-09.
+ */
+@Component
+public class KobjectConverter
+    extends AbstractHttpMessageConverter<Kobject> {
+
+  public KobjectConverter() {
+    super(MediaType.APPLICATION_JSON_UTF8,
+        MediaType.APPLICATION_JSON,
+        new MediaType("applicaion","ld+json")
+        );
+  }
+
+  @Override
+  public boolean canWrite(Class<?> clazz, org.springframework.http.MediaType mediaType) {
+    return false;
+  }
+
+  @Override
+  protected boolean supports(Class<?> clazz) {
+    return Kobject.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  protected Kobject readInternal(Class<? extends Kobject> clazz, HttpInputMessage inputMessage)
+      throws IOException, HttpMessageNotReadableException {
+    Kobject kob = KobjectImporter.jsonToKobject(inputMessage.getBody());
+    return kob;
+  }
+
+  //Do more than a dummy implementation in order to write Kobjects to ouput stream.
+  @Override
+  protected void writeInternal(Kobject kob, HttpOutputMessage outputMessage)
+      throws IOException, HttpMessageNotWritableException {
+    try {
+      OutputStream outputStream = outputMessage.getBody();
+      String body = kob.toString();
+      outputStream.write(body.getBytes());
+      outputStream.close();
+    } catch (Exception e) {
+    }
+  }
+}
+

--- a/activator/src/main/java/edu/umich/lhs/activator/services/KobjectImporter.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/KobjectImporter.java
@@ -20,6 +20,7 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.ResIterator;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.vocabulary.RDF;
 
 /**
@@ -137,7 +138,15 @@ public class KobjectImporter {
    * Deserialize the identifier (arkida) out of a rdf knowledge object resource
    */
   static ArkId deserializeIdentifier(Resource rdfKobject) {
-    return (new ArkId(rdfKobject.getProperty(identifierProp).getString()));
+    Statement identifier = rdfKobject.getProperty(identifierProp);
+    ArkId ark;
+    if(identifier == null){
+      ark = new ArkId();
+    }
+    else{
+      ark = new ArkId(rdfKobject.getProperty(identifierProp).getString());
+    }
+    return ark;
   }
 
   /**
@@ -145,11 +154,12 @@ public class KobjectImporter {
    */
   static Payload deserializePayload(Resource rdfKobject) {
     Resource rdfPayload = rdfKobject.getPropertyResourceValue(payloadProp);
-
     Payload payload = new Payload();
-    payload.setFunctionName(rdfPayload.getProperty(funcNameProp).getString());
-    payload.setEngineType(rdfPayload.getProperty(engineTypeProp).getString());
-    payload.setContent(rdfPayload.getProperty(contentProp).getString());
+    if(rdfPayload != null) {
+      payload.setFunctionName(rdfPayload.getProperty(funcNameProp).getString());
+      payload.setEngineType(rdfPayload.getProperty(engineTypeProp).getString());
+      payload.setContent(rdfPayload.getProperty(contentProp).getString());
+    }
 
     return payload;
   }
@@ -159,7 +169,11 @@ public class KobjectImporter {
    */
   static Integer deserializeNoofParams(Resource rdfKobject) {
     Resource inpMsg = rdfKobject.getPropertyResourceValue(inpMsgProp);
-    return inpMsg.getProperty(noOfParamsProp).getInt();
+    if(inpMsg == null){
+      return 0;
+    } else {
+      return inpMsg.getProperty(noOfParamsProp).getInt();
+    }
   }
 
   /**
@@ -170,6 +184,10 @@ public class KobjectImporter {
 
     // Get input message as intermediate step
     Resource inpMsg = rdfKobject.getPropertyResourceValue(inpMsgProp);
+
+    if(inpMsg == null){
+      return params;
+    }
 
     NodeIterator itt = inpMsg.getProperty(hasParams).getSeq().iterator();
     while (itt.hasNext()) {
@@ -198,10 +216,17 @@ public class KobjectImporter {
   static Class deserializeReturnType(Resource rdfKobject) {
     Resource outMsg = rdfKobject.getPropertyResourceValue(outMsgProp);
 
-    String retTypeString = outMsg.getProperty(retTypeProp).getString();
-    DataType retType = EnumUtils.getEnum(DataType.class, retTypeString);
+    if(outMsg != null){
+      Statement rTypeProp = outMsg.getProperty(retTypeProp);
 
-    return (dataClasses.getOrDefault(retType, Object.class));
+      if(rTypeProp != null){
+        String retTypeString = outMsg.getProperty(retTypeProp).getString();
+        DataType retType = EnumUtils.getEnum(DataType.class, retTypeString);
+        return (dataClasses.getOrDefault(retType, Object.class));
+      }
+    }
+
+    return Object.class;
   }
 
 }

--- a/activator/src/main/java/edu/umich/lhs/activator/services/KobjectImporter.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/KobjectImporter.java
@@ -1,0 +1,200 @@
+package edu.umich.lhs.activator.services;
+
+
+import edu.umich.lhs.activator.domain.ArkId;
+import edu.umich.lhs.activator.domain.DataType;
+import edu.umich.lhs.activator.domain.Kobject;
+import edu.umich.lhs.activator.domain.ParamDescription;
+import edu.umich.lhs.activator.domain.Payload;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.NodeIterator;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.ResIterator;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.vocabulary.RDF;
+
+/**
+ * Created by grosscol on 2017-09-11.
+ */
+public class KobjectImporter {
+
+  // Knoweldge Grid namespace
+  private static final String KGRID_NS = "http://lhs.umich.edu/kgrid#";
+  // Predicates
+  public static final String KNOWLEDGE_OBJECT_URI = KGRID_NS + "knowledgeObject";
+  public static final String HAS_INPUT_MESSAGE_URI = KGRID_NS + "hasInputMessage";
+  public static final String HAS_OUTPUT_MESSAGE_URI = KGRID_NS + "hasOutputMessage";
+  public static final String HAS_PAYLOAD_URI = KGRID_NS + "hasPayload";
+  public static final String NUM_OF_PARAMS_URI = KGRID_NS + "noofparams";
+  public static final String HAS_PARAMS_URI = KGRID_NS + "hasParams";
+  public static final String PARAM_NAME_URI = KGRID_NS + "paramname";
+  public static final String DATA_TYPE_URI = KGRID_NS + "datatype";
+  public static final String RETURN_TYPE_URI = KGRID_NS + "returnType";
+  public static final String FUNCTION_NAME_URI = KGRID_NS + "functionName";
+  public static final String CONTENT_URI = KGRID_NS + "content";
+  public static final String ENGINE_TYPE_URI = KGRID_NS + "engineType";
+  public static final String IDENTIFIER_URI = "http://schema.org/identifier";
+
+  // Reference Resource
+  public static final Resource kobjectRDFClass = ResourceFactory.createResource(KNOWLEDGE_OBJECT_URI);
+
+  // Reference Properties
+  public static final Property payloadProp = ResourceFactory.createProperty(HAS_PAYLOAD_URI);
+  public static final Property funcNameProp = ResourceFactory.createProperty(FUNCTION_NAME_URI);
+  public static final Property engineTypeProp = ResourceFactory.createProperty(ENGINE_TYPE_URI);
+  public static final Property contentProp = ResourceFactory.createProperty(CONTENT_URI);
+  public static final Property inpMsgProp = ResourceFactory.createProperty(HAS_INPUT_MESSAGE_URI);
+  public static final Property outMsgProp = ResourceFactory.createProperty(HAS_OUTPUT_MESSAGE_URI);
+  public static final Property identifierProp = ResourceFactory.createProperty(IDENTIFIER_URI);
+  public static final Property noOfParamsProp = ResourceFactory.createProperty(NUM_OF_PARAMS_URI);
+  public static final Property hasParams = ResourceFactory.createProperty(HAS_PARAMS_URI);
+  public static final Property paramNameProp = ResourceFactory.createProperty(PARAM_NAME_URI);
+  public static final Property dataTypeProp = ResourceFactory.createProperty(DATA_TYPE_URI);
+  public static final Property retTypeProp = ResourceFactory.createProperty(RETURN_TYPE_URI);
+
+  // Mapping DataType to Class
+  static final Map<DataType, Class> dataClasses = mapClasses();
+
+  static Map<DataType, Class> mapClasses() {
+    HashMap<DataType, Class>m = new HashMap<>();
+    m.put(DataType.INT, Integer.class);
+    m.put(DataType.LONG, Long.class);
+    m.put(DataType.FLOAT, float.class);
+    m.put(DataType.STRING, String.class);
+    m.put(DataType.MAP, Map.class);
+    return m;
+  }
+
+  static Kobject jsonToKobject(String ins) {
+    ByteArrayInputStream stream = new ByteArrayInputStream(ins.getBytes());
+    return jsonToKobject(stream);
+  }
+
+  static Kobject jsonToKobject(InputStream ins) {
+    Model model = jsonToModel(ins);
+    return extractKobject(model);
+  }
+
+  static Kobject extractKobject(Model model){
+    Kobject kob = new Kobject();
+    Resource kobjectRdf = getSingleKobjectResource(model);
+
+    Payload payload = deserializePayload(kobjectRdf);
+    ArkId identifier = deserializeIdentifier(kobjectRdf);
+    Integer numParams = deserializeNoofParams(kobjectRdf);
+    ArrayList<ParamDescription> paramDescriptions = deserializeParameters(kobjectRdf);
+    Class returnClass = deserializeReturnType(kobjectRdf);
+
+    kob.setNoofParams(numParams);
+    kob.setParamDescriptions(paramDescriptions);
+    kob.setReturnType(returnClass);
+    kob.setIdentifier(identifier);
+    kob.setPayload(payload);
+    return kob;
+
+  }
+
+  /**
+   * Take json-ld serialization of Knowledge Object(s) and deserialize to RDF model
+   *
+   * @param ins json-ld input stream
+   * @return RDFModel
+   */
+  static Model jsonToModel(InputStream ins) {
+    Model model = ModelFactory.createDefaultModel();
+    model.read(ins, "http://example.com", "JSON-LD");
+
+    return model;
+  }
+
+  static Resource getSingleKobjectResource(Model model) {
+    ResIterator itt = model.listResourcesWithProperty(RDF.type, kobjectRDFClass);
+    if (itt.hasNext()) {
+      return itt.nextResource();
+    } else {
+      // Throw exception or return null?
+      // TODO: Return exception
+      return null;
+    }
+  }
+
+  /**
+   * Deserialize the identifier (arkida) out of a rdf knowledge object resource
+   */
+  static ArkId deserializeIdentifier(Resource rdfKobject) {
+    return (new ArkId(rdfKobject.getProperty(identifierProp).getString()));
+  }
+
+  /**
+   * Deserialize payload out of a rdf knowledge object resource
+   */
+  static Payload deserializePayload(Resource rdfKobject) {
+    Resource rdfPayload = rdfKobject.getPropertyResourceValue(payloadProp);
+
+    Payload payload = new Payload();
+    payload.setFunctionName(rdfPayload.getProperty(funcNameProp).getString());
+    payload.setEngineType(rdfPayload.getProperty(engineTypeProp).getString());
+    payload.setContent(rdfPayload.getProperty(contentProp).getString());
+
+    return payload;
+  }
+
+  /**
+   * Deserialize parameter descriptions out of a rdf knowledge object resource
+   */
+  static Integer deserializeNoofParams(Resource rdfKobject) {
+    Resource inpMsg = rdfKobject.getPropertyResourceValue(inpMsgProp);
+    return inpMsg.getProperty(noOfParamsProp).getInt();
+  }
+
+  /**
+   * Deserialize parameter descriptions out of a rdf knowledge object resource
+   */
+  static ArrayList<ParamDescription> deserializeParameters(Resource rdfKobject) {
+    ArrayList<ParamDescription> params = new ArrayList<>();
+
+    // Get input message as intermediate step
+    Resource inpMsg = rdfKobject.getPropertyResourceValue(inpMsgProp);
+
+    NodeIterator itt = inpMsg.getProperty(hasParams).getSeq().iterator();
+    while (itt.hasNext()) {
+      RDFNode node = itt.next();
+      if (node.isResource()) {
+        params.add(deserializeParamDescription(node.asResource()));
+      }
+    }
+    return params;
+  }
+
+  /**
+   * Deserialize single parameter descriptions out of a rdf parameter resource
+   */
+  static ParamDescription deserializeParamDescription(Resource rdfParam) {
+    return (new ParamDescription(
+        rdfParam.getProperty(paramNameProp).getString(),
+        DataType.valueOf(rdfParam.getProperty(dataTypeProp).getString()),
+        null, null)
+    );
+  }
+
+  /**
+   * Deserialize return class from rdf knowledge object resource
+   */
+  static Class deserializeReturnType(Resource rdfKobject) {
+    Resource outMsg = rdfKobject.getPropertyResourceValue(outMsgProp);
+
+    String retTypeString = outMsg.getProperty(retTypeProp).getString();
+    DataType retType = DataType.valueOf(retTypeString);
+
+    return (dataClasses.getOrDefault(retType, Object.class));
+  }
+
+}

--- a/activator/src/main/java/edu/umich/lhs/activator/services/KobjectImporter.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/KobjectImporter.java
@@ -45,7 +45,8 @@ public class KobjectImporter {
   public static final String IDENTIFIER_URI = "http://schema.org/identifier";
 
   // Reference Resource
-  public static final Resource kobjectRDFClass = ResourceFactory.createResource(KNOWLEDGE_OBJECT_URI);
+  public static final Resource kobjectRDFClass = ResourceFactory
+      .createResource(KNOWLEDGE_OBJECT_URI);
 
   // Reference Properties
   public static final Property payloadProp = ResourceFactory.createProperty(HAS_PAYLOAD_URI);
@@ -65,7 +66,7 @@ public class KobjectImporter {
   static final Map<DataType, Class> dataClasses = mapClasses();
 
   static Map<DataType, Class> mapClasses() {
-    HashMap<DataType, Class>m = new HashMap<>();
+    HashMap<DataType, Class> m = new HashMap<>();
     m.put(DataType.INT, Integer.class);
     m.put(DataType.LONG, Long.class);
     m.put(DataType.FLOAT, float.class);
@@ -84,7 +85,7 @@ public class KobjectImporter {
     return extractKobject(model);
   }
 
-  static Kobject extractKobject(Model model){
+  static Kobject extractKobject(Model model) {
     Kobject kob = new Kobject();
     Resource kobjectRdf = getSingleKobjectResource(model);
 

--- a/activator/src/main/java/edu/umich/lhs/activator/services/KobjectImporter.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/KobjectImporter.java
@@ -112,6 +112,7 @@ public class KobjectImporter {
    */
   static Model jsonToModel(InputStream ins) {
     Model model = ModelFactory.createDefaultModel();
+    // TODO Auto-generated constructor stub
     model.read(ins, "http://example.com", "JSON-LD");
 
     return model;

--- a/activator/src/main/java/edu/umich/lhs/activator/services/KobjectImporter.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/KobjectImporter.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.NodeIterator;
@@ -192,7 +193,7 @@ public class KobjectImporter {
     Resource outMsg = rdfKobject.getPropertyResourceValue(outMsgProp);
 
     String retTypeString = outMsg.getProperty(retTypeProp).getString();
-    DataType retType = DataType.valueOf(retTypeString);
+    DataType retType = EnumUtils.getEnum(DataType.class, retTypeString);
 
     return (dataClasses.getOrDefault(retType, Object.class));
   }

--- a/activator/src/main/java/edu/umich/lhs/activator/services/KobjectImporter.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/KobjectImporter.java
@@ -24,6 +24,9 @@ import org.apache.jena.vocabulary.RDF;
 
 /**
  * Created by grosscol on 2017-09-11.
+ *
+ * Conversion from JSON-LD to Kobject
+ * Accomplished by creating an RDF model from a JSON-LD input and then extracting relevant fields.
  */
 public class KobjectImporter {
 
@@ -75,12 +78,12 @@ public class KobjectImporter {
     return m;
   }
 
-  static Kobject jsonToKobject(String ins) {
+  public static Kobject jsonToKobject(String ins) {
     ByteArrayInputStream stream = new ByteArrayInputStream(ins.getBytes());
     return jsonToKobject(stream);
   }
 
-  static Kobject jsonToKobject(InputStream ins) {
+  public static Kobject jsonToKobject(InputStream ins) {
     Model model = jsonToModel(ins);
     return extractKobject(model);
   }
@@ -100,6 +103,7 @@ public class KobjectImporter {
     kob.setReturnType(returnClass);
     kob.setIdentifier(identifier);
     kob.setPayload(payload);
+    kob.setRdfModel(model);
     return kob;
 
   }

--- a/activator/src/main/java/edu/umich/lhs/activator/services/PayloadInputValidator.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/PayloadInputValidator.java
@@ -1,9 +1,11 @@
 package edu.umich.lhs.activator.services;
 
+import edu.umich.lhs.activator.domain.ParamDescription;
 import edu.umich.lhs.activator.domain.PayloadProvider;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Class to check the validity of an api supplied input with the intended target payload
@@ -13,7 +15,7 @@ public class PayloadInputValidator {
 
   final PayloadProvider pp;
   final Map<String, Object> input;
-  List<String> messages;
+  private List<String> messages;
 
   public PayloadInputValidator(final PayloadProvider provider, final Map<String, Object> inputData){
     pp = provider;
@@ -22,7 +24,14 @@ public class PayloadInputValidator {
   }
 
   public boolean isValid(){
-    return arityMatches() && paramNamesPresent() && paramTypesMatch() && paramValuesInRange();
+    boolean result = false;
+    if(input == null){
+      messages.add("No inputs given.");
+    }
+    else if(arityMatches() & paramNamesPresent() & paramTypesMatch() & paramValuesInRange()){
+        result = true;
+    }
+    return result;
   }
 
   public List<String> messages(){
@@ -32,19 +41,43 @@ public class PayloadInputValidator {
   // Specific validity requirements
 
   boolean arityMatches(){
-    return pp.getNoOfParams() == input.size();
+    boolean result =  pp.getNoOfParams() == input.size();
+    if(result == false){
+      messages.add("Number of input parameters should be "+pp.getNoOfParams());
+    }
+    return result;
   }
 
   boolean paramNamesPresent(){
-    return false;
+    boolean result = true;
+    for(ParamDescription param : pp.getParams()){
+      if(!input.containsKey(param.getName())){
+        result = false;
+        messages.add("Input parameter "+param.getName()+" is missing.");
+      }
+    }
+    return result;
   }
 
+  /* This seems untennable as Java makes assumptions about number formats that
+  other languages do not.  e.g. NA in the R language could be a valid input to an integer
+  parameter.
+   */
   boolean paramTypesMatch(){
-    return false;
+    return true;
   }
 
+  // Same problem as above.  There is not language agnostic way to get this correct.
   boolean paramValuesInRange(){
     return false;
   }
+
+  public String getMessage() {
+    if(messages.isEmpty()){
+      return("");
+    }
+    return( StringUtils.join(messages, "\n  ") );
+  }
+
 
 }

--- a/activator/src/main/java/edu/umich/lhs/activator/services/PayloadInputValidator.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/PayloadInputValidator.java
@@ -1,0 +1,50 @@
+package edu.umich.lhs.activator.services;
+
+import edu.umich.lhs.activator.domain.PayloadProvider;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class to check the validity of an api supplied input with the intended target payload
+ * Created by grosscol on 2017-09-14.
+ */
+public class PayloadInputValidator {
+
+  final PayloadProvider pp;
+  final Map<String, Object> input;
+  List<String> messages;
+
+  public PayloadInputValidator(final PayloadProvider provider, final Map<String, Object> inputData){
+    pp = provider;
+    input = inputData;
+    messages = new ArrayList<>();
+  }
+
+  public boolean isValid(){
+    return arityMatches() && paramNamesPresent() && paramTypesMatch() && paramValuesInRange();
+  }
+
+  public List<String> messages(){
+    return messages;
+  }
+
+  // Specific validity requirements
+
+  boolean arityMatches(){
+    return pp.getNoOfParams() == input.size();
+  }
+
+  boolean paramNamesPresent(){
+    return false;
+  }
+
+  boolean paramTypesMatch(){
+    return false;
+  }
+
+  boolean paramValuesInRange(){
+    return false;
+  }
+
+}

--- a/activator/src/main/java/edu/umich/lhs/activator/services/PayloadProviderValidator.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/PayloadProviderValidator.java
@@ -1,0 +1,37 @@
+package edu.umich.lhs.activator.services;
+
+import edu.umich.lhs.activator.domain.PayloadProvider;
+
+/**
+ * Created by grosscol on 2017-09-11.
+ */
+public class PayloadProviderValidator {
+
+  private final PayloadProvider provider;
+  private String message;
+
+  public PayloadProviderValidator(final PayloadProvider provider) {
+    this.provider = provider;
+  }
+
+  public boolean verify(){
+    message = "";
+    return false;
+  }
+
+  public boolean verifyInputArity(){
+    message += "Arity problem";
+    return false;
+  }
+
+  public boolean verifyParameters(){
+    message += "Parameter problem";
+    return false;
+  }
+
+  public boolean verifyParameterLimits(){
+    message += "Parameter Limit problem";
+    return false;
+  }
+
+}

--- a/activator/src/main/java/edu/umich/lhs/activator/services/PayloadProviderValidator.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/PayloadProviderValidator.java
@@ -20,19 +20,19 @@ public class PayloadProviderValidator {
     this.provider = provider;
   }
 
-  public boolean verify(){
+  public boolean verify() {
     message = "";
     boolean result = false;
-    if( verifyInputArity() && verifyFunctionName() &&
-        verifyPayloadContent() && verifyReturnType() ){
+    if (verifyInputArity() && verifyFunctionName() &&
+        verifyPayloadContent() && verifyReturnType()) {
       message = VALIDATED_MESSAGE;
       result = true;
     }
     return result;
   }
 
-  public boolean verifyInputArity(){
-    if( provider.getNoOfParams() == provider.getParams().size()){
+  public boolean verifyInputArity() {
+    if (provider.getNoOfParams() == provider.getParams().size()) {
       return true;
     }
     message += ARITY_MESSAGE;
@@ -41,16 +41,16 @@ public class PayloadProviderValidator {
     return false;
   }
 
-  public boolean verifyFunctionName(){
-    if(provider.getFunctionName() != null && !provider.getFunctionName().isEmpty()){
+  public boolean verifyFunctionName() {
+    if (provider.getFunctionName() != null && !provider.getFunctionName().isEmpty()) {
       return true;
     }
     message += FUNC_NAME_MESSAGE;
     return false;
   }
 
-  public boolean verifyPayloadContent(){
-    if(provider.getContent() != null && !provider.getContent().isEmpty()){
+  public boolean verifyPayloadContent() {
+    if (provider.getContent() != null && !provider.getContent().isEmpty()) {
       return true;
     }
 
@@ -58,8 +58,8 @@ public class PayloadProviderValidator {
     return false;
   }
 
-  public boolean verifyReturnType(){
-    if(provider.getReturnType() != null){
+  public boolean verifyReturnType() {
+    if (provider.getReturnType() != null) {
       return true;
     }
     message += RETURN_TYPE_MESSAGE;

--- a/activator/src/main/java/edu/umich/lhs/activator/services/PayloadProviderValidator.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/PayloadProviderValidator.java
@@ -7,8 +7,14 @@ import edu.umich.lhs.activator.domain.PayloadProvider;
  */
 public class PayloadProviderValidator {
 
+  public static final String VALIDATED_MESSAGE = "payload provider valid.";
+  public static final String ARITY_MESSAGE = "Incorrect number of parameters declared.";
+  public static final String FUNC_NAME_MESSAGE = "Function does not have valid name.";
+  public static final String CONTENT_MESSAGE = "Content is empty.";
+  public static final String RETURN_TYPE_MESSAGE = "Invalid return type.";
+
   private final PayloadProvider provider;
-  private String message;
+  private String message = "";
 
   public PayloadProviderValidator(final PayloadProvider provider) {
     this.provider = provider;
@@ -16,22 +22,51 @@ public class PayloadProviderValidator {
 
   public boolean verify(){
     message = "";
-    return false;
+    boolean result = false;
+    if( verifyInputArity() && verifyFunctionName() &&
+        verifyPayloadContent() && verifyReturnType() ){
+      message = VALIDATED_MESSAGE;
+      result = true;
+    }
+    return result;
   }
 
   public boolean verifyInputArity(){
-    message += "Arity problem";
+    if( provider.getNoOfParams() == provider.getParams().size()){
+      return true;
+    }
+    message += ARITY_MESSAGE;
+    message += " Expected: " + provider.getNoOfParams();
+    message += " Found: " + provider.getParams().size();
     return false;
   }
 
-  public boolean verifyParameters(){
-    message += "Parameter problem";
+  public boolean verifyFunctionName(){
+    if(provider.getFunctionName() != null && !provider.getFunctionName().isEmpty()){
+      return true;
+    }
+    message += FUNC_NAME_MESSAGE;
     return false;
   }
 
-  public boolean verifyParameterLimits(){
-    message += "Parameter Limit problem";
+  public boolean verifyPayloadContent(){
+    if(provider.getContent() != null && !provider.getContent().isEmpty()){
+      return true;
+    }
+
+    message += CONTENT_MESSAGE;
     return false;
   }
 
+  public boolean verifyReturnType(){
+    if(provider.getReturnType() != null){
+      return true;
+    }
+    message += RETURN_TYPE_MESSAGE;
+    return false;
+  }
+
+  public String getMessage() {
+    return message;
+  }
 }

--- a/activator/src/main/java/edu/umich/lhs/activator/services/PayloadProviderValidator.java
+++ b/activator/src/main/java/edu/umich/lhs/activator/services/PayloadProviderValidator.java
@@ -10,7 +10,7 @@ public class PayloadProviderValidator {
   public static final String VALIDATED_MESSAGE = "payload provider valid.";
   public static final String ARITY_MESSAGE = "Incorrect number of parameters declared.";
   public static final String FUNC_NAME_MESSAGE = "Function does not have valid name.";
-  public static final String CONTENT_MESSAGE = "Content is empty.";
+  public static final String CONTENT_MESSAGE = "Knowledge object payload content is empty";
   public static final String RETURN_TYPE_MESSAGE = "Invalid return type.";
 
   private final PayloadProvider provider;

--- a/activator/src/main/resources/shelf/hello-world
+++ b/activator/src/main/resources/shelf/hello-world
@@ -1,18 +1,108 @@
 {
-  "metadata":{
-    "title":"Hello World",
-    "description":"Hello world sample object",
-    "published":true,
-    "lastModified":1486962000000,
-    "createdOn":1485838800000,
-    "citations":[]
-  },
-  "inputMessage":"<rdf:RDF xmlns:ot=\"http://uofm.org/objectteller/#\"\n         xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n    <rdf:Description rdf:about=\"http://uofm.org/objectteller/inputMessage\">\n        <ot:noofparams>1</ot:noofparams>\n        <ot:params>\n            <rdf:Seq>\n                <rdf:li>name</rdf:li>\n            </rdf:Seq>\n        </ot:params>\n    </rdf:Description>\n    <rdf:Description rdf:about=\"http://uofm.org/objectteller/inputs/\">\n        <ot:datatype>STRING</ot:datatype>\n    </rdf:Description>\n</rdf:RDF>\n",
-  "outputMessage":"<rdf:RDF xmlns:ot=\"http://uofm.org/objectteller/\"\n  xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n  <rdf:Description rdf:about=\"http://uofm.org/objectteller/outputMessage\">\n    <ot:returntype>STRING</ot:returntype>\n  </rdf:Description>\n</rdf:RDF>\n",
-  "payload":{
-    "content":"function execute(inputs){name = inputs.name; return \"Hello, \" + name;}",
-    "functionName":"execute",
-    "engineType":"JS"
-  },
-  "url": "http://n2t.net/ark:/hello/world"
+  "@graph": [
+    {
+      "@id": "http://example.com/UUID-0000-0000-0001",
+      "@type": "kgrid:knowledgeObject",
+      "hasInputMessage": {
+        "@type": "kgrid:inputMessage",
+        "hasParams": {
+          "@type": "rdf:Seq",
+          "_1": {
+            "@type": "kgrid:parameter",
+            "datatype": "STRING",
+            "paramname": "name"
+          }
+        },
+        "noofparams": "1"
+      },
+      "hasOutputMessage": {
+        "@type": "kgrid:outputMessage",
+        "returnType": "STRING"
+      },
+      "hasPayload": {
+        "@type": "kgrid:payload",
+        "content": "function execute(inputs){name = inputs.name; return \"Hello, \" + name;}",
+        "engineType": "JS",
+        "functionName": "execute"
+      },
+      "identifier": "ark:/hello/world",
+      "url": "http://n2t.net/ark:/hello/world",
+      "title":"Hello World",
+      "description":"Hello world sample object",
+      "published":true,
+      "lastModified": "",
+      "createdOn": ""
+    }
+  ],
+  "@context": {
+    "_1": {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1",
+      "@type": "@id"
+    },
+    "identifier": {
+      "@id": "http://schema.org/identifier"
+    },
+    "url": {
+      "@id": "http://schema.org/url"
+    },
+    "hasPayload": {
+      "@id": "http://lhs.umich.edu/kgrid#hasPayload",
+      "@type": "@id"
+    },
+    "hasOutputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasOutputMessage",
+      "@type": "@id"
+    },
+    "hasInputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasInputMessage",
+      "@type": "@id"
+    },
+    "returnType": {
+      "@id": "http://lhs.umich.edu/kgrid#returnType"
+    },
+    "datatype": {
+      "@id": "http://lhs.umich.edu/kgrid#datatype"
+    },
+    "paramname": {
+      "@id": "http://lhs.umich.edu/kgrid#paramname"
+    },
+    "hasParams": {
+      "@id": "http://lhs.umich.edu/kgrid#hasParams",
+      "@type": "@id"
+    },
+    "noofparams": {
+      "@id": "http://lhs.umich.edu/kgrid#noofparams"
+    },
+    "engineType": {
+      "@id": "http://lhs.umich.edu/kgrid#engineType"
+    },
+    "content": {
+      "@id": "http://lhs.umich.edu/kgrid#content"
+    },
+    "functionName": {
+      "@id": "http://lhs.umich.edu/kgrid#functionName"
+    },
+    "bibliographicCitation": {
+      "@id": "http://purl.org/dc/terms/bibliographicCitation"
+    },
+    "created": {
+      "@id": "http://purl.org/dc/terms/created"
+    },
+    "modified": {
+      "@id": "http://purl.org/dc/terms/modified"
+    },
+    "published": {
+      "@id": "http://lhs.umich.edu/kgrid#published"
+    },
+    "description": {
+      "@id": "http://purl.org/dc/terms/description"
+    },
+    "title": {
+      "@id": "http://purl.org/dc/terms/title"
+    },
+    "dc": "http://purl.org/dc/terms/",
+    "schema": "http://schema.org/",
+    "kgrid": "http://lhs.umich.edu/kgrid#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
 }

--- a/activator/src/main/resources/shelf/prescription-counter
+++ b/activator/src/main/resources/shelf/prescription-counter
@@ -1,13 +1,108 @@
 {
-  "inputMessage": "<rdf:RDF xmlns:ot=\"http://uofm.org/objectteller/#\"\n xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n  <rdf:Description rdf:about=\"http://uofm.org/objectteller/inputMessage\">\n    <ot:noofparams>1</ot:noofparams>\n    <ot:params>\n      <rdf:Seq>\n        <rdf:li>DrugIDs</rdf:li>\n      </rdf:Seq>\n    </ot:params>\n  </rdf:Description>\n  <rdf:Description rdf:about=\"http://uofm.org/objectteller/DrugIDs/\">\n    <ot:datatype>STRING</ot:datatype>\n  </rdf:Description>\n</rdf:RDF>\n",
-  "outputMessage": "<rdf:RDF xmlns:ot=\"http://uofm.org/objectteller/\"\n  xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n  <rdf:Description rdf:about=\"http://uofm.org/objectteller/outputMessage\">\n    <ot:returntype>INT</ot:returntype>\n  </rdf:Description>\n</rdf:RDF>\n",
-  "payload": {
-    "content": "function TotalPrescriptions(DrugIDDict){ rxcuistring = DrugIDDict.DrugIDs; if(rxcuistring === \"\") {  return 0; } rxcuis=rxcuistring.split(\" \"); return rxcuis.length;}function test(){ if (TotalPrescriptions({\"DrugIDs\":\"\"}) === 0) {  console.log (\"ok.\"); } else {  console.log (\"error.\"); } if (TotalPrescriptions({\"DrugIDs\":\"101 204 708 406 190\"}) === 5) {  console.log (\"ok.\"); } else {  console.log (\"error.\"); } if (TotalPrescriptions({\"DrugIDs\":\"101 204 708\"}) === 3) {  console.log (\"ok.\"); } else {  console.log (\"error.\"); }}",
-    "engineType": "JS",
-    "functionName": "TotalPrescriptions"
-  },
-  "metadata": {
-    "title": "Prescription Counter"
-  },
-  "url": "http://n2t.net/ark:/prescription/counter"
+  "@graph": [
+    {
+      "@id": "http://example.com/UUID-0000-0000-0002",
+      "@type": "kgrid:knowledgeObject",
+      "hasInputMessage": {
+        "@type": "kgrid:inputMessage",
+        "hasParams": {
+          "@type": "rdf:Seq",
+          "_1": {
+            "@type": "kgrid:parameter",
+            "datatype": "STRING",
+            "paramname": "DrugIDDict"
+          }
+        },
+        "noofparams": "1"
+      },
+      "hasOutputMessage": {
+        "@type": "kgrid:outputMessage",
+        "returnType": "STRING"
+      },
+      "hasPayload": {
+        "@type": "kgrid:payload",
+        "content": "function TotalPrescriptions(DrugIDDict){ rxcuistring = DrugIDDict.DrugIDs; if(rxcuistring === \"\") {  return 0; } rxcuis=rxcuistring.split(\" \"); return rxcuis.length;}function test(){ if (TotalPrescriptions({\"DrugIDs\":\"\"}) === 0) {  console.log (\"ok.\"); } else {  console.log (\"error.\"); } if (TotalPrescriptions({\"DrugIDs\":\"101 204 708 406 190\"}) === 5) {  console.log (\"ok.\"); } else {  console.log (\"error.\"); } if (TotalPrescriptions({\"DrugIDs\":\"101 204 708\"}) === 3) {  console.log (\"ok.\"); } else {  console.log (\"error.\"); }}",
+        "engineType": "JS",
+        "functionName": "TotalPrescriptions"
+      },
+      "identifier": "ark:/hello/world",
+      "url": "http://n2t.net/ark:/prescription/counter",
+      "title":"Perscription Counter",
+      "description":"Hello world sample object",
+      "published":true,
+      "lastModified": "",
+      "createdOn": ""
+    }
+  ],
+  "@context": {
+    "_1": {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1",
+      "@type": "@id"
+    },
+    "identifier": {
+      "@id": "http://schema.org/identifier"
+    },
+    "url": {
+      "@id": "http://schema.org/url"
+    },
+    "hasPayload": {
+      "@id": "http://lhs.umich.edu/kgrid#hasPayload",
+      "@type": "@id"
+    },
+    "hasOutputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasOutputMessage",
+      "@type": "@id"
+    },
+    "hasInputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasInputMessage",
+      "@type": "@id"
+    },
+    "returnType": {
+      "@id": "http://lhs.umich.edu/kgrid#returnType"
+    },
+    "datatype": {
+      "@id": "http://lhs.umich.edu/kgrid#datatype"
+    },
+    "paramname": {
+      "@id": "http://lhs.umich.edu/kgrid#paramname"
+    },
+    "hasParams": {
+      "@id": "http://lhs.umich.edu/kgrid#hasParams",
+      "@type": "@id"
+    },
+    "noofparams": {
+      "@id": "http://lhs.umich.edu/kgrid#noofparams"
+    },
+    "engineType": {
+      "@id": "http://lhs.umich.edu/kgrid#engineType"
+    },
+    "content": {
+      "@id": "http://lhs.umich.edu/kgrid#content"
+    },
+    "functionName": {
+      "@id": "http://lhs.umich.edu/kgrid#functionName"
+    },
+    "bibliographicCitation": {
+      "@id": "http://purl.org/dc/terms/bibliographicCitation"
+    },
+    "created": {
+      "@id": "http://purl.org/dc/terms/created"
+    },
+    "modified": {
+      "@id": "http://purl.org/dc/terms/modified"
+    },
+    "published": {
+      "@id": "http://lhs.umich.edu/kgrid#published"
+    },
+    "description": {
+      "@id": "http://purl.org/dc/terms/description"
+    },
+    "title": {
+      "@id": "http://purl.org/dc/terms/title"
+    },
+    "dc": "http://purl.org/dc/terms/",
+    "schema": "http://schema.org/",
+    "kgrid": "http://lhs.umich.edu/kgrid#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
 }

--- a/activator/src/test/java/edu/umich/lhs/activator/TestUtils.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/TestUtils.java
@@ -58,11 +58,11 @@ public class TestUtils {
 
   public static final String CODE = "function execute(a){ return a.toString()}";
 
-  public static byte[] convertObjectToJsonBytes(Object object) throws IOException {
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    return mapper.writeValueAsBytes(object);
-  }
+//  public static byte[] convertObjectToJsonBytes(Object object) throws IOException {
+//    ObjectMapper mapper = new ObjectMapper();
+//    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+//    return mapper.writeValueAsBytes(object);
+//  }
 
   // Helper function to retrieve string fixtures from test package resources
   public static String loadFixture(String fixtureName) throws IOException {

--- a/activator/src/test/java/edu/umich/lhs/activator/TestUtils.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/TestUtils.java
@@ -3,7 +3,9 @@ package edu.umich.lhs.activator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.Scanner;
 import org.springframework.http.MediaType;
 
 /**
@@ -61,5 +63,28 @@ public class TestUtils {
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     return mapper.writeValueAsBytes(object);
   }
+
+  // Helper function to retrieve string fixtures from test package resources
+  public static String loadFixture(String fixtureName) throws IOException {
+    String fixture = new Scanner(
+        TestUtils.class.getResourceAsStream("/fixtures/" + fixtureName), "UTF-8")
+        .useDelimiter("\\A").next();
+    return fixture;
+  }
+
+  public static String safeLoadFixture(String fixtureName){
+    try{
+      return loadFixture(fixtureName);
+    }catch(IOException ex){
+      return "";
+    }
+  }
+
+  // Helper function to stream fixtures from test package resources
+  public static InputStream streamFixture(String fixtureName) throws IOException {
+    InputStream ins = TestUtils.class.getResourceAsStream("/fixtures/" + fixtureName);
+    return ins;
+  }
+
 
 }

--- a/activator/src/test/java/edu/umich/lhs/activator/controller/ShelfControllerTest.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/controller/ShelfControllerTest.java
@@ -106,15 +106,15 @@ public class ShelfControllerTest {
 
     @Test
     public void addBlankKOtoShelf() throws Exception {
-        KnowledgeObject ko = new KnowledgeObjectBuilder().build();
+        String blankJson = TestUtils.loadFixture("kobject-empty.json");
 
-//        mockMvc.perform(put("/shelf/ark:/{naan}/{name}","99999", "fk4df70k9j")
-//            .contentType(TestUtils.APPLICATION_JSON_UTF8)
-//            .content(TestUtils.convertObjectToJsonBytes(ko))
-//        )
-//            .andExpect(status().isOk())
-//            .andExpect(content().contentType(TestUtils.APPLICATION_TEXT_UTF8))
-//            .andExpect(content().string("Object ark:/99999/fk4df70k9j added to the shelf"));
+        mockMvc.perform(put("/shelf/ark:/{naan}/{name}","99999", "fk4df70k9j")
+            .contentType(TestUtils.APPLICATION_JSON_UTF8)
+            .content(blankJson)
+        )
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(TestUtils.APPLICATION_TEXT_UTF8))
+            .andExpect(content().string("Object ark:/99999/fk4df70k9j added to the shelf"));
     }
 
     @Test

--- a/activator/src/test/java/edu/umich/lhs/activator/controller/ShelfControllerTest.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/controller/ShelfControllerTest.java
@@ -15,6 +15,8 @@ import edu.umich.lhs.activator.KgridActivatorApplication;
 import edu.umich.lhs.activator.TestUtils;
 import edu.umich.lhs.activator.domain.ArkId;
 import edu.umich.lhs.activator.domain.KnowledgeObject;
+import edu.umich.lhs.activator.domain.Kobject;
+import edu.umich.lhs.activator.domain.KobjectBuilder;
 import edu.umich.lhs.activator.repository.Shelf;
 import java.io.File;
 import java.io.IOException;
@@ -89,7 +91,7 @@ public class ShelfControllerTest {
     @Test
     public void getObjectFromLocalShelf() throws Exception {
 
-        KnowledgeObject ko = new KnowledgeObjectBuilder().build();
+        Kobject ko = new KobjectBuilder().build();
         ArkId arkId = new ArkId("99999", "fk4df70k9j");
 
         shelf.saveObject(ko, arkId);
@@ -106,18 +108,18 @@ public class ShelfControllerTest {
     public void addBlankKOtoShelf() throws Exception {
         KnowledgeObject ko = new KnowledgeObjectBuilder().build();
 
-        mockMvc.perform(put("/shelf/ark:/{naan}/{name}","99999", "fk4df70k9j")
-            .contentType(TestUtils.APPLICATION_JSON_UTF8)
-            .content(TestUtils.convertObjectToJsonBytes(ko))
-        )
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(TestUtils.APPLICATION_TEXT_UTF8))
-            .andExpect(content().string("Object ark:/99999/fk4df70k9j added to the shelf"));
+//        mockMvc.perform(put("/shelf/ark:/{naan}/{name}","99999", "fk4df70k9j")
+//            .contentType(TestUtils.APPLICATION_JSON_UTF8)
+//            .content(TestUtils.convertObjectToJsonBytes(ko))
+//        )
+//            .andExpect(status().isOk())
+//            .andExpect(content().contentType(TestUtils.APPLICATION_TEXT_UTF8))
+//            .andExpect(content().string("Object ark:/99999/fk4df70k9j added to the shelf"));
     }
 
     @Test
     public void deleteObjectFromShelf() throws Exception {
-        KnowledgeObject ko = new KnowledgeObjectBuilder().build();
+        Kobject ko = new KobjectBuilder().build();
         ArkId arkId = new ArkId("99999", "fk4df70k9j");
 
         shelf.saveObject(ko, arkId);
@@ -131,7 +133,7 @@ public class ShelfControllerTest {
 
     @Test
     public void insertBlankObjectOntoShelfAndRetrievePayload() throws Exception {
-        KnowledgeObject ko = new KnowledgeObjectBuilder().build();
+        Kobject ko = new KobjectBuilder().build();
         ArkId arkId = new ArkId("99999", "fk4df70k9j");
 
         shelf.saveObject(ko, arkId);
@@ -143,7 +145,7 @@ public class ShelfControllerTest {
 
     @Test
     public void insertPayloadObjectOntoShelfAndRetrievePayload() throws Exception {
-        KnowledgeObject ko = new KnowledgeObjectBuilder()
+        Kobject ko = new KobjectBuilder()
             .payloadContent("payload")
             .build();
         ArkId arkId = new ArkId("99999", "fk4df70k9j");

--- a/activator/src/test/java/edu/umich/lhs/activator/domain/KnowledgeObjectBuilder.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/domain/KnowledgeObjectBuilder.java
@@ -1,6 +1,6 @@
 package edu.umich.lhs.activator.domain;
 
-import edu.umich.lhs.activator.domain.KnowledgeObject.Payload;
+import edu.umich.lhs.activator.domain.Payload;
 
 /**
  * Created by nggittle on 3/27/2017.

--- a/activator/src/test/java/edu/umich/lhs/activator/domain/KobjectBuilder.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/domain/KobjectBuilder.java
@@ -1,0 +1,109 @@
+package edu.umich.lhs.activator.domain;
+
+import static edu.umich.lhs.activator.services.KobjectImporter.KNOWLEDGE_OBJECT_URI;
+import static edu.umich.lhs.activator.services.KobjectImporter.identifierProp;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+
+/**
+ * Created by grosscol on 2018-01-04.
+ */
+public class KobjectBuilder {
+  private Kobject ko;
+
+  public KobjectBuilder() {
+    ko = new Kobject();
+  }
+
+  public KobjectBuilder metadata(Metadata metadata) {
+    ko.metadata = metadata;
+    return this;
+  }
+
+  public KobjectBuilder noofParams(Integer i) {
+    ko.setNoofParams(i);
+    return this;
+  }
+
+  public KobjectBuilder addParamDescription(String name, DataType dataType, Integer min, Integer max){
+    ParamDescription p = new ParamDescription(name, dataType, min, max);
+    ko.addParamDescriptions(p);
+    return this;
+  }
+
+  public KobjectBuilder returnType(Class c) {
+    ko.setReturnType(c);
+    return this;
+  }
+
+  public KobjectBuilder payload(Payload payload) {
+    ko.setPayload(payload);
+    return this;
+  }
+
+  public KobjectBuilder url(String url) {
+    ko.setUrl(url);
+    return this;
+  }
+
+  public KobjectBuilder payloadContent (String content) {
+    if(ko.getPayload() != null) {
+      ko.getPayload().setContent(content);
+    } else {
+      ko.setPayload(new Payload(content, "",""));
+    }
+    return this;
+  }
+
+  public KobjectBuilder payloadFunctionName (String functionName) {
+    if(ko.getPayload() != null) {
+      ko.getPayload().setFunctionName(functionName);
+    } else {
+      ko.setPayload(new Payload("","",functionName));
+    }
+    return this;
+  }
+
+  public KobjectBuilder payloadEngineType (String engineType) {
+    if(ko.getPayload() != null) {
+      ko.getPayload().setEngineType(engineType);
+    } else {
+      ko.setPayload(new Payload("",engineType, ""));
+    }
+    return this;
+  }
+
+  public KobjectBuilder arkID(ArkId ark){
+    ko.setIdentifier(ark);
+    return this;
+  }
+
+  // Build a minimal RDF Model to allow saving something with an ark
+  private Model buildModel(Kobject ko){
+    String identifier;
+    if(ko.getIdentifier() == null){
+      identifier = new ArkId("foo","bar").toString();
+    }
+    else{
+      identifier = ko.getIdentifier().toString();
+    }
+
+    Resource kobjectType = ResourceFactory.createResource(KNOWLEDGE_OBJECT_URI);
+    Model model = ModelFactory.createDefaultModel();
+    model.createResource("http://example.com/1", kobjectType)
+        .addProperty(identifierProp, identifier);
+
+    return model;
+  }
+
+  public Kobject build(){
+    ko.setRdfModel(buildModel(ko));
+    return ko;
+  }
+
+
+
+}

--- a/activator/src/test/java/edu/umich/lhs/activator/services/ActivationServiceTest.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/services/ActivationServiceTest.java
@@ -1,8 +1,11 @@
 package edu.umich.lhs.activator.services;
 
 import edu.umich.lhs.activator.TestUtils;
+import edu.umich.lhs.activator.domain.DataType;
 import edu.umich.lhs.activator.domain.KnowledgeObject;
 import edu.umich.lhs.activator.domain.KnowledgeObjectBuilder;
+import edu.umich.lhs.activator.domain.Kobject;
+import edu.umich.lhs.activator.domain.KobjectBuilder;
 import edu.umich.lhs.activator.domain.Result;
 import edu.umich.lhs.activator.exception.ActivatorException;
 import org.junit.Rule;
@@ -25,6 +28,8 @@ import static org.junit.Assert.assertNotNull;
 @SpringBootTest
 public class ActivationServiceTest {
 
+  public static final String payload_code = "function execute(a){ return a.toString()}";
+
   @Autowired
   private ActivationService activationService;
 
@@ -41,17 +46,21 @@ public class ActivationServiceTest {
   @Test
   public void testCalculateWithEmptyKOandNullInputs() throws Exception {
 
-    KnowledgeObject ko = new KnowledgeObject();
+    Kobject ko = new Kobject();
     expectedEx.expect(ActivatorException.class);
     expectedEx.expectMessage("No inputs given.");
     assertNotNull(activationService.validateAndExecute(null, ko));
   }
 
+  //TODO: Move this spec to a test of the Validator
   @Test
   public void testCalculateWithWrongInput() throws Exception {
-    KnowledgeObject ko = new KnowledgeObjectBuilder()
-        .inputMessage(TestUtils.INPUT_SPEC_ONE_INPUT)
-        .outputMessage(TestUtils.OUTPUT_SPEC_RET_STR)
+    Kobject ko = new KobjectBuilder()
+        .addParamDescription("rxcui", DataType.STRING, 1, 1)
+        .returnType(String.class)
+        .payloadEngineType("JAVASCRIPT")
+        .payloadFunctionName("execute")
+        .payloadContent(payload_code)
         .build();
     Map<String, Object> inputs = new HashMap<>();
     inputs.put("test", "test");
@@ -62,9 +71,12 @@ public class ActivationServiceTest {
 
   @Test
   public void testCalculateWithCorrectInputsButNoPayload() {
-    KnowledgeObject ko = new KnowledgeObjectBuilder()
-        .inputMessage(TestUtils.INPUT_SPEC_ONE_INPUT)
-        .outputMessage(TestUtils.OUTPUT_SPEC_RET_STR)
+    Kobject ko = new KobjectBuilder()
+        .addParamDescription("rxcui", DataType.STRING, 1, 1)
+        .returnType(String.class)
+        .payloadEngineType("JAVASCRIPT")
+        .payloadFunctionName("execute")
+        .payloadContent(payload_code)
         .build();
     Map<String, Object> inputs = new HashMap<>();
     inputs.put("rxcui", "test");
@@ -79,12 +91,12 @@ public class ActivationServiceTest {
 
   @Test
   public void testCalculateWithSyntaxErrorToThrowEx() {
-    KnowledgeObject ko = new KnowledgeObjectBuilder()
-        .inputMessage(TestUtils.INPUT_SPEC_ONE_INPUT)
-        .outputMessage(TestUtils.OUTPUT_SPEC_RET_STR)
-        .payloadContent("function execute(a) return a}") // Syntax error
+    Kobject ko = new KobjectBuilder()
+        .addParamDescription("rxcui", DataType.INT, 1, 1)
+        .returnType(String.class)
         .payloadEngineType("JAVASCRIPT")
         .payloadFunctionName("execute")
+        .payloadContent(payload_code)
         .build();
 
     Map<String, Object> inputs = new HashMap<>();
@@ -93,19 +105,20 @@ public class ActivationServiceTest {
     expectedResult.setSource(null);
 
     expectedEx.expect(ActivatorException.class);
-//    expectedEx.expectMessage(contains("Error occurred while executing javascript code SyntaxError:"));
     Result generatedResult = activationService.validateAndExecute(inputs, ko);
-
   }
 
+  //TODO: Ensure validator is called
+
+  //TODO: Move this spec to a test of the Validator
   @Test
   public void testCalculateWithTooManyInputsToThrowEx() {
-    KnowledgeObject ko = new KnowledgeObjectBuilder()
-        .inputMessage(TestUtils.INPUT_SPEC_ONE_INPUT)
-        .outputMessage(TestUtils.OUTPUT_SPEC_RET_STR)
-        .payloadContent(TestUtils.CODE)
+    Kobject ko = new KobjectBuilder()
+        .addParamDescription("rxcui", DataType.INT, 1, 1)
+        .returnType(String.class)
         .payloadEngineType("JAVASCRIPT")
         .payloadFunctionName("execute")
+        .payloadContent(payload_code)
         .build();
 
     Map<String, Object> inputs = new HashMap<>();
@@ -119,14 +132,16 @@ public class ActivationServiceTest {
     Result generatedResult = activationService.validateAndExecute(inputs, ko);
   }
 
+  //TODO: Move this spec to a test of the Validator
   @Test
   public void testCalculateWithTooFewInputsToThrowEx() {
-    KnowledgeObject ko = new KnowledgeObjectBuilder()
-        .inputMessage(TestUtils.INPUT_SPEC_TWO_INPUTS)
-        .outputMessage(TestUtils.OUTPUT_SPEC_RET_STR)
-        .payloadContent(TestUtils.CODE)
+    Kobject ko = new KobjectBuilder()
+        .addParamDescription("rxcui", DataType.INT, 1, 1)
+        .addParamDescription("rxcui2", DataType.INT, 1, 1)
+        .returnType(String.class)
         .payloadEngineType("JAVASCRIPT")
         .payloadFunctionName("execute")
+        .payloadContent(payload_code)
         .build();
 
     Map<String, Object> inputs = new HashMap<>();
@@ -139,14 +154,16 @@ public class ActivationServiceTest {
     Result generatedResult = activationService.validateAndExecute(inputs, ko);
   }
 
+  //TODO: Move this spec to a test of the Validator
   @Test
   public void testStringReturnedWhenExpectIntToThrowEx() {
-    KnowledgeObject ko = new KnowledgeObjectBuilder()
-        .inputMessage(TestUtils.INPUT_SPEC_ONE_INPUT)
-        .outputMessage(TestUtils.OUTPUT_SPEC_RET_INT)
-        .payloadContent(TestUtils.CODE)
+    Kobject ko = new KobjectBuilder()
+        .addParamDescription("rxcui", DataType.INT, 1, 1)
+        .addParamDescription("rxcui2", DataType.INT, 1, 1)
+        .returnType(Integer.class)
         .payloadEngineType("JAVASCRIPT")
         .payloadFunctionName("execute")
+        .payloadContent(payload_code)
         .build();
     Map<String, Object> inputs = new HashMap<>();
     inputs.put("rxcui", "1723222");

--- a/activator/src/test/java/edu/umich/lhs/activator/services/KobjectImporterTest.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/services/KobjectImporterTest.java
@@ -1,0 +1,166 @@
+package edu.umich.lhs.activator.services;
+
+import edu.umich.lhs.activator.domain.ArkId;
+import edu.umich.lhs.activator.domain.DataType;
+import edu.umich.lhs.activator.domain.ParamDescription;
+import edu.umich.lhs.activator.domain.Payload;
+import java.util.ArrayList;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.mem.GraphMem;
+import org.apache.jena.rdf.model.AnonId;
+import org.apache.jena.rdf.model.Model;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isOneOf;
+import static org.junit.Assert.*;
+
+import edu.umich.lhs.activator.TestUtils;
+import edu.umich.lhs.activator.domain.Kobject;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.Seq;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.impl.ModelCom;
+import org.apache.jena.rdf.model.impl.PropertyImpl;
+import org.apache.jena.rdf.model.impl.StatementImpl;
+import org.apache.jena.util.MonitorModel;
+import org.apache.jena.vocabulary.RDF;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+
+/**
+ * Created by grosscol on 2017-09-12.
+ */
+public class KobjectImporterTest {
+
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  private final String SAMPLE_JSON_KOBJECT = TestUtils.safeLoadFixture("kobject-sample.json");
+
+  private InputStream inStream;
+  private Model model;
+  private Resource kobjectRdf;
+
+  @Before
+  public void setUp() throws Exception {
+    inStream = new ByteArrayInputStream(SAMPLE_JSON_KOBJECT.getBytes());
+    model = ModelFactory.createDefaultModel();
+    kobjectRdf = model.createResource("http://example.com/001", KobjectImporter.kobjectRDFClass);
+  }
+
+  // Behavior tests
+  @Test
+  public void smokeTest() throws Exception {
+    KobjectImporter.jsonToKobject(inStream);
+  }
+
+  @Test
+  public void makesOneOfManyKobjects() throws Exception {
+    InputStream ins = TestUtils.streamFixture("kobject-multiple.json");
+    Kobject kob = KobjectImporter.jsonToKobject(ins);
+    assertThat(kob.getIdentifier().getArkId(), equalTo("ark:/1234/56second"));
+  }
+
+
+  // Unit tests
+  @Test
+  public void getSingleKobject() throws Exception {
+    Resource kobjectOne = model.createResource("http://example.com/001", KobjectImporter.kobjectRDFClass);
+    Resource kobjectTwo = model.createResource("http://example.com/002", KobjectImporter.kobjectRDFClass);
+
+    Resource result = KobjectImporter.getSingleKobjectResource(model);
+    assertThat(result, isOneOf(kobjectOne, kobjectTwo));
+  }
+
+  @Test
+  public void deserializeIdentifier() throws Exception {
+    String ark = "ark:/1234/foo";
+    kobjectRdf.addProperty(KobjectImporter.identifierProp, ark);
+
+    ArkId deserializedArk = KobjectImporter.deserializeIdentifier(kobjectRdf);
+
+    ArkId checkArk = new ArkId(ark);
+    assertThat(deserializedArk, equalTo(checkArk));
+  }
+
+  @Test
+  public void deserializePayload() throws Exception {
+    String content = "foo(){ print('Hello') }";
+    String engineType = "SmallCapable";
+    String funcName = "foo";
+
+    Resource payloadRDF = model.createResource(new AnonId("1"));
+
+    kobjectRdf.addProperty(KobjectImporter.payloadProp, payloadRDF);
+    payloadRDF.addProperty(KobjectImporter.contentProp, content);
+    payloadRDF.addProperty(KobjectImporter.engineTypeProp, engineType);
+    payloadRDF.addProperty(KobjectImporter.funcNameProp, funcName);
+
+    Payload p = KobjectImporter.deserializePayload(kobjectRdf);
+
+    Payload check = new Payload();
+    check.setContent(content);
+    check.setEngineType(engineType);
+    check.setFunctionName(funcName);
+
+    assertThat(p.getContent(), equalTo(check.getContent()));
+    assertThat(p.getEngineType(), equalTo(check.getEngineType()));
+    assertThat(p.getFunctionName(), equalTo(check.getFunctionName()));
+  }
+
+  @Test
+  public void deserializeNoofParams() throws Exception {
+    Integer numParams = 2;
+    Resource inputMessage = model.createResource(AnonId.create());
+
+    kobjectRdf.addProperty(KobjectImporter.inpMsgProp, inputMessage);
+    inputMessage.addLiteral(KobjectImporter.noOfParamsProp, numParams);
+
+    Integer result = KobjectImporter.deserializeNoofParams(kobjectRdf);
+
+    assertThat(result, equalTo(numParams));
+  }
+
+  @Test
+  public void deserializeParameters() throws Exception {
+    Resource inputMessage = model.createResource(AnonId.create());
+    Seq paramSeq = model.createSeq();
+    Resource param1 = model.createResource(AnonId.create());
+    Resource param2 = model.createResource(AnonId.create());
+
+    kobjectRdf.addProperty(KobjectImporter.inpMsgProp, inputMessage);
+    inputMessage.addProperty(KobjectImporter.hasParams, paramSeq);
+
+    param1.addLiteral(KobjectImporter.paramNameProp, "foo")
+        .addLiteral(KobjectImporter.dataTypeProp, "STRING");
+    param2.addLiteral(KobjectImporter.paramNameProp, "bar")
+        .addLiteral(KobjectImporter.dataTypeProp, "INT");
+    paramSeq.add(param1)
+        .add(param2);
+
+    ParamDescription p1 = new ParamDescription("foo", DataType.STRING , null, null);
+    ParamDescription p2 = new ParamDescription("bar", DataType.INT, null, null);
+
+    ArrayList<ParamDescription> pList = KobjectImporter.deserializeParameters(kobjectRdf);
+
+    assertThat(pList.size(), equalTo(2));
+  }
+
+  @Test
+  public void deserializeParamDescription() throws Exception {
+    //TODO
+  }
+
+  @Test
+  public void deserializeReturnType() throws Exception {
+    //TODO
+  }
+
+}

--- a/activator/src/test/java/edu/umich/lhs/activator/services/KobjectImporterTest.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/services/KobjectImporterTest.java
@@ -1,21 +1,21 @@
 package edu.umich.lhs.activator.services;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isOneOf;
+import static org.junit.Assert.assertThat;
+
+import edu.umich.lhs.activator.TestUtils;
 import edu.umich.lhs.activator.domain.ArkId;
 import edu.umich.lhs.activator.domain.DataType;
+import edu.umich.lhs.activator.domain.Kobject;
 import edu.umich.lhs.activator.domain.ParamDescription;
 import edu.umich.lhs.activator.domain.Payload;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Map;
 import org.apache.jena.rdf.model.AnonId;
 import org.apache.jena.rdf.model.Model;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isOneOf;
-import static org.junit.Assert.*;
-
-import edu.umich.lhs.activator.TestUtils;
-import edu.umich.lhs.activator.domain.Kobject;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Seq;
@@ -30,11 +30,9 @@ import org.junit.rules.ExpectedException;
  */
 public class KobjectImporterTest {
 
+  private final String SAMPLE_JSON_KOBJECT = TestUtils.safeLoadFixture("kobject-sample.json");
   @Rule
   public ExpectedException expectedEx = ExpectedException.none();
-
-  private final String SAMPLE_JSON_KOBJECT = TestUtils.safeLoadFixture("kobject-sample.json");
-
   private InputStream inStream;
   private Model model;
   private Resource kobjectRdf;
@@ -63,8 +61,10 @@ public class KobjectImporterTest {
   // Unit tests
   @Test
   public void getSingleKobject() throws Exception {
-    Resource kobjectOne = model.createResource("http://example.com/001", KobjectImporter.kobjectRDFClass);
-    Resource kobjectTwo = model.createResource("http://example.com/002", KobjectImporter.kobjectRDFClass);
+    Resource kobjectOne = model
+        .createResource("http://example.com/001", KobjectImporter.kobjectRDFClass);
+    Resource kobjectTwo = model
+        .createResource("http://example.com/002", KobjectImporter.kobjectRDFClass);
 
     Resource result = KobjectImporter.getSingleKobjectResource(model);
     assertThat(result, isOneOf(kobjectOne, kobjectTwo));
@@ -137,7 +137,7 @@ public class KobjectImporterTest {
     paramSeq.add(param1)
         .add(param2);
 
-    ParamDescription p1 = new ParamDescription("foo", DataType.STRING , null, null);
+    ParamDescription p1 = new ParamDescription("foo", DataType.STRING, null, null);
     ParamDescription p2 = new ParamDescription("bar", DataType.INT, null, null);
 
     ArrayList<ParamDescription> pList = KobjectImporter.deserializeParameters(kobjectRdf);

--- a/activator/src/test/java/edu/umich/lhs/activator/services/KobjectImporterTest.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/services/KobjectImporterTest.java
@@ -5,8 +5,7 @@ import edu.umich.lhs.activator.domain.DataType;
 import edu.umich.lhs.activator.domain.ParamDescription;
 import edu.umich.lhs.activator.domain.Payload;
 import java.util.ArrayList;
-import org.apache.jena.graph.Graph;
-import org.apache.jena.mem.GraphMem;
+import java.util.Map;
 import org.apache.jena.rdf.model.AnonId;
 import org.apache.jena.rdf.model.Model;
 import static org.hamcrest.Matchers.equalTo;
@@ -18,16 +17,8 @@ import edu.umich.lhs.activator.domain.Kobject;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.rdf.model.Seq;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.rdf.model.impl.ModelCom;
-import org.apache.jena.rdf.model.impl.PropertyImpl;
-import org.apache.jena.rdf.model.impl.StatementImpl;
-import org.apache.jena.util.MonitorModel;
-import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -110,6 +101,7 @@ public class KobjectImporterTest {
     check.setEngineType(engineType);
     check.setFunctionName(funcName);
 
+    //TODO: Better method for equivalence testing Payloads
     assertThat(p.getContent(), equalTo(check.getContent()));
     assertThat(p.getEngineType(), equalTo(check.getEngineType()));
     assertThat(p.getFunctionName(), equalTo(check.getFunctionName()));
@@ -150,17 +142,42 @@ public class KobjectImporterTest {
 
     ArrayList<ParamDescription> pList = KobjectImporter.deserializeParameters(kobjectRdf);
 
+    //TODO: Method for equivalence testing Parameters
     assertThat(pList.size(), equalTo(2));
   }
 
   @Test
   public void deserializeParamDescription() throws Exception {
-    //TODO
+    Resource paramRdf = model.createResource(AnonId.create());
+    paramRdf.addProperty(KobjectImporter.paramNameProp, "foo");
+    paramRdf.addProperty(KobjectImporter.dataTypeProp, "INT");
+
+    ParamDescription check = new ParamDescription("foo", DataType.INT, null, null);
+
+    ParamDescription result = KobjectImporter.deserializeParamDescription(paramRdf);
+
+    assertThat(result.getDatatype(), equalTo(check.getDatatype()));
+    assertThat(result.getName(), equalTo(check.getName()));
   }
 
   @Test
   public void deserializeReturnType() throws Exception {
-    //TODO
+    Resource outMsg = model.createResource(KobjectImporter.outMsgProp);
+    outMsg.addProperty(KobjectImporter.retTypeProp, "MAP");
+    kobjectRdf.addProperty(KobjectImporter.outMsgProp, outMsg);
+
+    Class result = KobjectImporter.deserializeReturnType(kobjectRdf);
+    assertThat(result, equalTo(Map.class));
+  }
+
+  @Test
+  public void defaultReturnType() throws Exception {
+    Resource outMsg = model.createResource(KobjectImporter.outMsgProp);
+    outMsg.addProperty(KobjectImporter.retTypeProp, "NONEXTANTCLASS");
+    kobjectRdf.addProperty(KobjectImporter.outMsgProp, outMsg);
+
+    Class result = KobjectImporter.deserializeReturnType(kobjectRdf);
+    assertThat(result, equalTo(Object.class));
   }
 
 }

--- a/activator/src/test/java/edu/umich/lhs/activator/services/PayloadProviderValidatorTest.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/services/PayloadProviderValidatorTest.java
@@ -1,0 +1,61 @@
+package edu.umich.lhs.activator.services;
+
+import static org.junit.Assert.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.umich.lhs.activator.domain.Kobject;
+import edu.umich.lhs.activator.domain.Payload;
+import edu.umich.lhs.activator.domain.PayloadProvider;
+import java.util.ArrayList;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+
+/**
+ * Created by grosscol on 2017-09-11.
+ */
+public class PayloadProviderValidatorTest {
+
+  PayloadProvider pp = mock(PayloadProvider.class);
+  PayloadProviderValidator validator;
+
+  @Rule
+  public ExpectedException expectedEx = ExpectedException.none();
+
+  @Before
+  public void setUp() throws Exception {
+    validator = new PayloadProviderValidator(pp);
+  }
+
+  @Test
+  public void validatesZeroParams() throws Exception {
+    when(pp.getNoOfParams()).thenReturn(0);
+    when(pp.getParams()).thenReturn(new ArrayList<>());
+
+    boolean result = validator.verifyInputArity();
+    assertThat(result, equalTo(true));
+  }
+
+  @Test
+  public void messageForBadArity() throws Exception {
+  }
+
+  @Test
+  public void verifyParameters() throws Exception {
+  }
+
+  @Test
+  public void verifyParameterLimits() throws Exception {
+  }
+
+}

--- a/activator/src/test/java/edu/umich/lhs/activator/services/PayloadProviderValidatorTest.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/services/PayloadProviderValidatorTest.java
@@ -23,15 +23,13 @@ import org.junit.rules.ExpectedException;
  */
 public class PayloadProviderValidatorTest {
 
-  private PayloadProvider pp = mock(PayloadProvider.class);
-  private PayloadProviderValidator validator;
-
   // Source dummy parameters
   private final ParamDescription foo = new ParamDescription("foo", DataType.STRING, null, null);
   private final ParamDescription bar = new ParamDescription("bar", DataType.INT, -5, 20);
-
   @Rule
   public ExpectedException expectedEx = ExpectedException.none();
+  private PayloadProvider pp = mock(PayloadProvider.class);
+  private PayloadProviderValidator validator;
 
   @Before
   public void setUp() throws Exception {

--- a/activator/src/test/java/edu/umich/lhs/activator/services/PayloadProviderValidatorTest.java
+++ b/activator/src/test/java/edu/umich/lhs/activator/services/PayloadProviderValidatorTest.java
@@ -1,20 +1,17 @@
 package edu.umich.lhs.activator.services;
 
-import static org.junit.Assert.*;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsSame.sameInstance;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import edu.umich.lhs.activator.domain.Kobject;
-import edu.umich.lhs.activator.domain.Payload;
+import edu.umich.lhs.activator.domain.DataType;
+import edu.umich.lhs.activator.domain.ParamDescription;
 import edu.umich.lhs.activator.domain.PayloadProvider;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,8 +23,12 @@ import org.junit.rules.ExpectedException;
  */
 public class PayloadProviderValidatorTest {
 
-  PayloadProvider pp = mock(PayloadProvider.class);
-  PayloadProviderValidator validator;
+  private PayloadProvider pp = mock(PayloadProvider.class);
+  private PayloadProviderValidator validator;
+
+  // Source dummy parameters
+  private final ParamDescription foo = new ParamDescription("foo", DataType.STRING, null, null);
+  private final ParamDescription bar = new ParamDescription("bar", DataType.INT, -5, 20);
 
   @Rule
   public ExpectedException expectedEx = ExpectedException.none();
@@ -37,6 +38,32 @@ public class PayloadProviderValidatorTest {
     validator = new PayloadProviderValidator(pp);
   }
 
+  // Informational Messages
+  @Test
+  public void noMessageBeforeValidation() throws Exception {
+    when(pp.getNoOfParams()).thenReturn(2);
+    when(pp.getParams()).thenReturn(new ArrayList<>());
+
+    String msg = validator.getMessage();
+    assertThat(msg, equalTo(""));
+  }
+
+  @Test
+  public void successfulValidationMessage() throws Exception {
+    when(pp.getNoOfParams()).thenReturn(2);
+    ArrayList<ParamDescription> params = new ArrayList<>(Arrays.asList(foo, bar));
+    when(pp.getParams()).thenReturn(params);
+    when(pp.getFunctionName()).thenReturn("myFun");
+    when(pp.getContent()).thenReturn("dummy Content");
+    when(pp.getEngineType()).thenReturn("dummy engine");
+    when(pp.getReturnType()).thenReturn(String.class);
+
+    validator.verify();
+    String msg = validator.getMessage();
+    assertThat(msg, equalTo(PayloadProviderValidator.VALIDATED_MESSAGE));
+  }
+
+  // Parameter Arity
   @Test
   public void validatesZeroParams() throws Exception {
     when(pp.getNoOfParams()).thenReturn(0);
@@ -47,15 +74,106 @@ public class PayloadProviderValidatorTest {
   }
 
   @Test
+  public void validatesParamCount() throws Exception {
+    when(pp.getNoOfParams()).thenReturn(2);
+
+    ArrayList<ParamDescription> params = new ArrayList<>(Arrays.asList(foo, bar));
+    when(pp.getParams()).thenReturn(params);
+
+    boolean result = validator.verifyInputArity();
+    assertThat(result, equalTo(true));
+  }
+
+  @Test
+  public void catchFewerParams() throws Exception {
+    when(pp.getNoOfParams()).thenReturn(2);
+    ArrayList<ParamDescription> params = new ArrayList<>(Collections.singletonList(foo));
+    when(pp.getParams()).thenReturn(params);
+
+    boolean result = validator.verifyInputArity();
+    assertThat(result, equalTo(false));
+  }
+
+  @Test
+  public void catchMoreParams() throws Exception {
+    when(pp.getNoOfParams()).thenReturn(0);
+    ArrayList<ParamDescription> params = new ArrayList<>(Collections.singletonList(foo));
+    when(pp.getParams()).thenReturn(params);
+
+    boolean result = validator.verifyInputArity();
+    assertThat(result, equalTo(false));
+  }
+
+  @Test
   public void messageForBadArity() throws Exception {
+    when(pp.getNoOfParams()).thenReturn(2);
+    ArrayList<ParamDescription> params = new ArrayList<>(Collections.singletonList(foo));
+    when(pp.getParams()).thenReturn(params);
+
+    validator.verifyInputArity();
+    String msg = validator.getMessage();
+    assertThat(msg, containsString(PayloadProviderValidator.ARITY_MESSAGE));
+  }
+
+  // Function Name Check
+  @Test
+  public void blankName() throws Exception {
+    when(pp.getFunctionName()).thenReturn("");
+
+    boolean result = validator.verifyFunctionName();
+    assertThat(result, equalTo(false));
   }
 
   @Test
-  public void verifyParameters() throws Exception {
+  public void nullName() throws Exception {
+    when(pp.getFunctionName()).thenReturn(null);
+
+    boolean result = validator.verifyFunctionName();
+    assertThat(result, equalTo(false));
   }
 
   @Test
-  public void verifyParameterLimits() throws Exception {
+  public void nameMessage() throws Exception {
+    when(pp.getFunctionName()).thenReturn(null);
+
+    validator.verifyFunctionName();
+    String msg = validator.getMessage();
+    assertThat(msg, equalTo(PayloadProviderValidator.FUNC_NAME_MESSAGE));
+  }
+
+  // Payload Content Check
+  @Test
+  public void blankContent() throws Exception {
+    when(pp.getContent()).thenReturn("");
+
+    boolean result = validator.verifyPayloadContent();
+    assertThat(result, equalTo(false));
+  }
+
+  @Test
+  public void nullContent() throws Exception {
+    when(pp.getContent()).thenReturn(null);
+
+    boolean result = validator.verifyPayloadContent();
+    assertThat(result, equalTo(false));
+  }
+
+  @Test
+  public void contentMessage() throws Exception {
+    when(pp.getFunctionName()).thenReturn(null);
+
+    validator.verifyPayloadContent();
+    String msg = validator.getMessage();
+    assertThat(msg, equalTo(PayloadProviderValidator.CONTENT_MESSAGE));
+  }
+
+  // Return Type Check
+  @Test
+  public void nullReturnType() throws Exception {
+    when(pp.getReturnType()).thenReturn(null);
+
+    boolean result = validator.verifyReturnType();
+    assertThat(result, equalTo(false));
   }
 
 }

--- a/activator/src/test/resources/fixtures/kobject-bnodes.json
+++ b/activator/src/test/resources/fixtures/kobject-bnodes.json
@@ -1,0 +1,101 @@
+{
+  "@graph": [
+    {
+      "@id": "_:bnode0",
+      "@type": "kgrid:outputMessage",
+      "returnType": "MAP"
+    },
+    {
+      "@id": "_:bnode1",
+      "@type": "rdf:Seq",
+      "_1": "_:bnode3",
+      "_2": "_:bnode2"
+    },
+    {
+      "@id": "_:bnode2",
+      "@type": "kgrid:parameter",
+      "datatype": "INT",
+      "paramname": "bar"
+    },
+    {
+      "@id": "_:bnode3",
+      "@type": "kgrid:parameter",
+      "datatype": "STRING",
+      "paramname": "foo"
+    },
+    {
+      "@id": "_:bnode4",
+      "@type": "kgrid:payload",
+      "content": "def perform(params):\n    return  {'Hello': 'World'}\n",
+      "engineType": "Python",
+      "functionName": "hello()"
+    },
+    {
+      "@id": "_:bnode5",
+      "@type": "kgrid:inputMessage",
+      "hasParams": "_:bnode1",
+      "noofparams": "2"
+    },
+    {
+      "@id": "http://example.com/UUID-0000-0000-0001",
+      "@type": "kgrid:knowledgeObject",
+      "hasInputMessage": "_:bnode5",
+      "hasOutputMessage": "_:bnode0",
+      "hasPayload": "_:bnode4",
+      "identifier": "ark:/1234/56somekobject"
+    }
+  ],
+  "@context": {
+    "returnType": {
+      "@id": "http://lhs.umich.edu/kgrid#returnType"
+    },
+    "_2": {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_2",
+      "@type": "@id"
+    },
+    "_1": {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1",
+      "@type": "@id"
+    },
+    "identifier": {
+      "@id": "http://schema.org/identifier"
+    },
+    "hasPayload": {
+      "@id": "http://lhs.umich.edu/kgrid#hasPayload",
+      "@type": "@id"
+    },
+    "hasOutputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasOutputMessage",
+      "@type": "@id"
+    },
+    "hasInputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasInputMessage",
+      "@type": "@id"
+    },
+    "engineType": {
+      "@id": "http://lhs.umich.edu/kgrid#engineType"
+    },
+    "content": {
+      "@id": "http://lhs.umich.edu/kgrid#content"
+    },
+    "functionName": {
+      "@id": "http://lhs.umich.edu/kgrid#functionName"
+    },
+    "datatype": {
+      "@id": "http://lhs.umich.edu/kgrid#datatype"
+    },
+    "paramname": {
+      "@id": "http://lhs.umich.edu/kgrid#paramname"
+    },
+    "hasParams": {
+      "@id": "http://lhs.umich.edu/kgrid#hasParams",
+      "@type": "@id"
+    },
+    "noofparams": {
+      "@id": "http://lhs.umich.edu/kgrid#noofparams"
+    },
+    "schema": "http://schema.org/",
+    "kgrid": "http://lhs.umich.edu/kgrid#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/activator/src/test/resources/fixtures/kobject-empty.json
+++ b/activator/src/test/resources/fixtures/kobject-empty.json
@@ -1,0 +1,79 @@
+{
+  "@graph": [
+    {
+      "@id": "http://example.com/UUID-0000-0000-0001",
+      "@type": "kgrid:knowledgeObject"
+    }
+  ],
+  "@context": {
+    "_1": {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1",
+      "@type": "@id"
+    },
+    "identifier": {
+      "@id": "http://schema.org/identifier"
+    },
+    "url": {
+      "@id": "http://schema.org/url"
+    },
+    "hasPayload": {
+      "@id": "http://lhs.umich.edu/kgrid#hasPayload",
+      "@type": "@id"
+    },
+    "hasOutputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasOutputMessage",
+      "@type": "@id"
+    },
+    "hasInputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasInputMessage",
+      "@type": "@id"
+    },
+    "returnType": {
+      "@id": "http://lhs.umich.edu/kgrid#returnType"
+    },
+    "datatype": {
+      "@id": "http://lhs.umich.edu/kgrid#datatype"
+    },
+    "paramname": {
+      "@id": "http://lhs.umich.edu/kgrid#paramname"
+    },
+    "hasParams": {
+      "@id": "http://lhs.umich.edu/kgrid#hasParams",
+      "@type": "@id"
+    },
+    "noofparams": {
+      "@id": "http://lhs.umich.edu/kgrid#noofparams"
+    },
+    "engineType": {
+      "@id": "http://lhs.umich.edu/kgrid#engineType"
+    },
+    "content": {
+      "@id": "http://lhs.umich.edu/kgrid#content"
+    },
+    "functionName": {
+      "@id": "http://lhs.umich.edu/kgrid#functionName"
+    },
+    "bibliographicCitation": {
+      "@id": "http://purl.org/dc/terms/bibliographicCitation"
+    },
+    "created": {
+      "@id": "http://purl.org/dc/terms/created"
+    },
+    "modified": {
+      "@id": "http://purl.org/dc/terms/modified"
+    },
+    "published": {
+      "@id": "http://lhs.umich.edu/kgrid#published"
+    },
+    "description": {
+      "@id": "http://purl.org/dc/terms/description"
+    },
+    "title": {
+      "@id": "http://purl.org/dc/terms/title"
+    },
+    "dc": "http://purl.org/dc/terms/",
+    "schema": "http://schema.org/",
+    "kgrid": "http://lhs.umich.edu/kgrid#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/activator/src/test/resources/fixtures/kobject-multiple.json
+++ b/activator/src/test/resources/fixtures/kobject-multiple.json
@@ -1,62 +1,65 @@
 {
-  "@graph": [{
-    "@id" : "http://example.com/UUID-0000-0000-0001",
-    "@type" : "kgrid:knowledgeObject",
-    "hasInputMessage" : {
-      "@type" : "kgrid:inputMessage",
-      "hasParams" : {
-        "@type" : "rdf:Seq",
-        "_1" : {
-          "@type" : "kgrid:parameter",
-          "datatype" : "INT",
-          "paramname" : "bar"
+  "@graph": [
+    {
+      "@id": "http://example.com/UUID-0000-0000-0001",
+      "@type": "kgrid:knowledgeObject",
+      "hasInputMessage": {
+        "@type": "kgrid:inputMessage",
+        "hasParams": {
+          "@type": "rdf:Seq",
+          "_1": {
+            "@type": "kgrid:parameter",
+            "datatype": "INT",
+            "paramname": "bar"
+          },
+          "_2": {
+            "@type": "kgrid:parameter",
+            "datatype": "STRING",
+            "paramname": "foo"
+          }
         },
-        "_2" : {
-          "@type" : "kgrid:parameter",
-          "datatype" : "STRING",
-          "paramname" : "foo"
-        }
+        "noofparams": "2"
       },
-      "noofparams" : "2"
-    },
-    "hasOutputMessage" : {
-      "@type" : "kgrid:outputMessage",
-      "returnType" : "MAP"
-    },
-    "hasPayload" : {
-      "@type" : "kgrid:payload",
-      "content" : "def perform(foo, bar):\n          return  {'Hello': 'World'}\n        ",
-      "engineType" : "Python",
-      "functionName" : "hello()"
-    },
-    "identifier" : "ark:/1234/56first"
-  },{
-    "@id" : "http://example.com/UUID-0000-0000-0002",
-    "@type" : "kgrid:knowledgeObject",
-    "hasInputMessage" : {
-      "@type" : "kgrid:inputMessage",
-      "hasParams" : {
-        "@type" : "rdf:Seq",
-        "_1" : {
-          "@type" : "kgrid:parameter",
-          "datatype" : "MAP",
-          "paramname" : "funparams"
-        }
+      "hasOutputMessage": {
+        "@type": "kgrid:outputMessage",
+        "returnType": "MAP"
       },
-      "noofparams" : "1"
+      "hasPayload": {
+        "@type": "kgrid:payload",
+        "content": "def perform(foo, bar):\n          return  {'Hello': 'World'}\n        ",
+        "engineType": "Python",
+        "functionName": "hello()"
+      },
+      "identifier": "ark:/1234/56first"
     },
-    "hasOutputMessage" : {
-      "@type" : "kgrid:outputMessage",
-      "returnType" : "MAP"
-    },
-    "hasPayload" : {
-      "@type" : "kgrid:payload",
-      "content" : "def perform(funparams):\n          return  {'Hello': 'World'}\n        ",
-      "engineType" : "Python",
-      "functionName" : "hello()"
-    },
-    "identifier" : "ark:/1234/56second"
-  } ],
+    {
+      "@id": "http://example.com/UUID-0000-0000-0002",
+      "@type": "kgrid:knowledgeObject",
+      "hasInputMessage": {
+        "@type": "kgrid:inputMessage",
+        "hasParams": {
+          "@type": "rdf:Seq",
+          "_1": {
+            "@type": "kgrid:parameter",
+            "datatype": "MAP",
+            "paramname": "funparams"
+          }
+        },
+        "noofparams": "1"
+      },
+      "hasOutputMessage": {
+        "@type": "kgrid:outputMessage",
+        "returnType": "MAP"
+      },
+      "hasPayload": {
+        "@type": "kgrid:payload",
+        "content": "def perform(funparams):\n          return  {'Hello': 'World'}\n        ",
+        "engineType": "Python",
+        "functionName": "hello()"
+      },
+      "identifier": "ark:/1234/56second"
+    }
+  ],
   "@context": {
     "returnType": {
       "@id": "http://lhs.umich.edu/kgrid#returnType"

--- a/activator/src/test/resources/fixtures/kobject-multiple.json
+++ b/activator/src/test/resources/fixtures/kobject-multiple.json
@@ -1,0 +1,113 @@
+{
+  "@graph": [{
+    "@id" : "http://example.com/UUID-0000-0000-0001",
+    "@type" : "kgrid:knowledgeObject",
+    "hasInputMessage" : {
+      "@type" : "kgrid:inputMessage",
+      "hasParams" : {
+        "@type" : "rdf:Seq",
+        "_1" : {
+          "@type" : "kgrid:parameter",
+          "datatype" : "INT",
+          "paramname" : "bar"
+        },
+        "_2" : {
+          "@type" : "kgrid:parameter",
+          "datatype" : "STRING",
+          "paramname" : "foo"
+        }
+      },
+      "noofparams" : "2"
+    },
+    "hasOutputMessage" : {
+      "@type" : "kgrid:outputMessage",
+      "returnType" : "MAP"
+    },
+    "hasPayload" : {
+      "@type" : "kgrid:payload",
+      "content" : "def perform(foo, bar):\n          return  {'Hello': 'World'}\n        ",
+      "engineType" : "Python",
+      "functionName" : "hello()"
+    },
+    "identifier" : "ark:/1234/56first"
+  },{
+    "@id" : "http://example.com/UUID-0000-0000-0002",
+    "@type" : "kgrid:knowledgeObject",
+    "hasInputMessage" : {
+      "@type" : "kgrid:inputMessage",
+      "hasParams" : {
+        "@type" : "rdf:Seq",
+        "_1" : {
+          "@type" : "kgrid:parameter",
+          "datatype" : "MAP",
+          "paramname" : "funparams"
+        }
+      },
+      "noofparams" : "1"
+    },
+    "hasOutputMessage" : {
+      "@type" : "kgrid:outputMessage",
+      "returnType" : "MAP"
+    },
+    "hasPayload" : {
+      "@type" : "kgrid:payload",
+      "content" : "def perform(funparams):\n          return  {'Hello': 'World'}\n        ",
+      "engineType" : "Python",
+      "functionName" : "hello()"
+    },
+    "identifier" : "ark:/1234/56second"
+  } ],
+  "@context": {
+    "returnType": {
+      "@id": "http://lhs.umich.edu/kgrid#returnType"
+    },
+    "_2": {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_2",
+      "@type": "@id"
+    },
+    "_1": {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1",
+      "@type": "@id"
+    },
+    "identifier": {
+      "@id": "http://schema.org/identifier"
+    },
+    "hasPayload": {
+      "@id": "http://lhs.umich.edu/kgrid#hasPayload",
+      "@type": "@id"
+    },
+    "hasOutputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasOutputMessage",
+      "@type": "@id"
+    },
+    "hasInputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasInputMessage",
+      "@type": "@id"
+    },
+    "engineType": {
+      "@id": "http://lhs.umich.edu/kgrid#engineType"
+    },
+    "content": {
+      "@id": "http://lhs.umich.edu/kgrid#content"
+    },
+    "functionName": {
+      "@id": "http://lhs.umich.edu/kgrid#functionName"
+    },
+    "datatype": {
+      "@id": "http://lhs.umich.edu/kgrid#datatype"
+    },
+    "paramname": {
+      "@id": "http://lhs.umich.edu/kgrid#paramname"
+    },
+    "hasParams": {
+      "@id": "http://lhs.umich.edu/kgrid#hasParams",
+      "@type": "@id"
+    },
+    "noofparams": {
+      "@id": "http://lhs.umich.edu/kgrid#noofparams"
+    },
+    "schema": "http://schema.org/",
+    "kgrid": "http://lhs.umich.edu/kgrid#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/activator/src/test/resources/fixtures/kobject-sample.json
+++ b/activator/src/test/resources/fixtures/kobject-sample.json
@@ -1,101 +1,87 @@
 {
-  "@graph": [
-    {
-      "@id": "_:bnode0",
-      "@type": "kgrid:outputMessage",
-      "returnType": "MAP"
+  "@graph" : [ {
+    "@id" : "http://example.com/UUID-0000-0000-0001",
+    "@type" : "kgrid:knowledgeObject",
+    "hasInputMessage" : {
+      "@type" : "kgrid:inputMessage",
+      "hasParams" : {
+        "@type" : "rdf:Seq",
+        "_1" : {
+          "@type" : "kgrid:parameter",
+          "datatype" : "INT",
+          "paramname" : "bar"
+        },
+        "_2" : {
+          "@type" : "kgrid:parameter",
+          "datatype" : "STRING",
+          "paramname" : "foo"
+        }
+      },
+      "noofparams" : "2"
     },
-    {
-      "@id": "_:bnode1",
-      "@type": "rdf:Seq",
-      "_1": "_:bnode3",
-      "_2": "_:bnode2"
+    "hasOutputMessage" : {
+      "@type" : "kgrid:outputMessage",
+      "returnType" : "MAP"
     },
-    {
-      "@id": "_:bnode2",
-      "@type": "kgrid:parameter",
-      "datatype": "INT",
-      "paramname": "bar"
+    "hasPayload" : {
+      "@type" : "kgrid:payload",
+      "content" : "def perform(params):\n          return  {'Hello': 'World'}\n        ",
+      "engineType" : "Python",
+      "functionName" : "hello()"
     },
-    {
-      "@id": "_:bnode3",
-      "@type": "kgrid:parameter",
-      "datatype": "STRING",
-      "paramname": "foo"
+    "identifier" : "ark:/1234/56somekobject"
+  } ],
+  "@context" : {
+    "_2" : {
+      "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#_2",
+      "@type" : "@id"
     },
-    {
-      "@id": "_:bnode4",
-      "@type": "kgrid:payload",
-      "content": "def perform(params):\n    return  {'Hello': 'World'}\n",
-      "engineType": "Python",
-      "functionName": "hello()"
+    "_1" : {
+      "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1",
+      "@type" : "@id"
     },
-    {
-      "@id": "_:bnode5",
-      "@type": "kgrid:inputMessage",
-      "hasParams": "_:bnode1",
-      "noofparams": "2"
+    "identifier" : {
+      "@id" : "http://schema.org/identifier"
     },
-    {
-      "@id": "http://example.com/UUID-0000-0000-0001",
-      "@type": "kgrid:knowledgeObject",
-      "hasInputMessage": "_:bnode5",
-      "hasOutputMessage": "_:bnode0",
-      "hasPayload": "_:bnode4",
-      "identifier": "ark:/1234/56somekobject"
-    }
-  ],
-  "@context": {
-    "returnType": {
-      "@id": "http://lhs.umich.edu/kgrid#returnType"
+    "hasPayload" : {
+      "@id" : "http://lhs.umich.edu/kgrid#hasPayload",
+      "@type" : "@id"
     },
-    "_2": {
-      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_2",
-      "@type": "@id"
+    "hasOutputMessage" : {
+      "@id" : "http://lhs.umich.edu/kgrid#hasOutputMessage",
+      "@type" : "@id"
     },
-    "_1": {
-      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1",
-      "@type": "@id"
+    "hasInputMessage" : {
+      "@id" : "http://lhs.umich.edu/kgrid#hasInputMessage",
+      "@type" : "@id"
     },
-    "identifier": {
-      "@id": "http://schema.org/identifier"
+    "returnType" : {
+      "@id" : "http://lhs.umich.edu/kgrid#returnType"
     },
-    "hasPayload": {
-      "@id": "http://lhs.umich.edu/kgrid#hasPayload",
-      "@type": "@id"
+    "datatype" : {
+      "@id" : "http://lhs.umich.edu/kgrid#datatype"
     },
-    "hasOutputMessage": {
-      "@id": "http://lhs.umich.edu/kgrid#hasOutputMessage",
-      "@type": "@id"
+    "paramname" : {
+      "@id" : "http://lhs.umich.edu/kgrid#paramname"
     },
-    "hasInputMessage": {
-      "@id": "http://lhs.umich.edu/kgrid#hasInputMessage",
-      "@type": "@id"
+    "hasParams" : {
+      "@id" : "http://lhs.umich.edu/kgrid#hasParams",
+      "@type" : "@id"
     },
-    "engineType": {
-      "@id": "http://lhs.umich.edu/kgrid#engineType"
+    "noofparams" : {
+      "@id" : "http://lhs.umich.edu/kgrid#noofparams"
     },
-    "content": {
-      "@id": "http://lhs.umich.edu/kgrid#content"
+    "engineType" : {
+      "@id" : "http://lhs.umich.edu/kgrid#engineType"
     },
-    "functionName": {
-      "@id": "http://lhs.umich.edu/kgrid#functionName"
+    "content" : {
+      "@id" : "http://lhs.umich.edu/kgrid#content"
     },
-    "datatype": {
-      "@id": "http://lhs.umich.edu/kgrid#datatype"
+    "functionName" : {
+      "@id" : "http://lhs.umich.edu/kgrid#functionName"
     },
-    "paramname": {
-      "@id": "http://lhs.umich.edu/kgrid#paramname"
-    },
-    "hasParams": {
-      "@id": "http://lhs.umich.edu/kgrid#hasParams",
-      "@type": "@id"
-    },
-    "noofparams": {
-      "@id": "http://lhs.umich.edu/kgrid#noofparams"
-    },
-    "schema": "http://schema.org/",
-    "kgrid": "http://lhs.umich.edu/kgrid#",
-    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    "schema" : "http://schema.org/",
+    "kgrid" : "http://lhs.umich.edu/kgrid#",
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   }
 }

--- a/activator/src/test/resources/fixtures/kobject-sample.json
+++ b/activator/src/test/resources/fixtures/kobject-sample.json
@@ -1,0 +1,101 @@
+{
+  "@graph": [
+    {
+      "@id": "_:bnode0",
+      "@type": "kgrid:outputMessage",
+      "returnType": "MAP"
+    },
+    {
+      "@id": "_:bnode1",
+      "@type": "rdf:Seq",
+      "_1": "_:bnode3",
+      "_2": "_:bnode2"
+    },
+    {
+      "@id": "_:bnode2",
+      "@type": "kgrid:parameter",
+      "datatype": "INT",
+      "paramname": "bar"
+    },
+    {
+      "@id": "_:bnode3",
+      "@type": "kgrid:parameter",
+      "datatype": "STRING",
+      "paramname": "foo"
+    },
+    {
+      "@id": "_:bnode4",
+      "@type": "kgrid:payload",
+      "content": "def perform(params):\n    return  {'Hello': 'World'}\n",
+      "engineType": "Python",
+      "functionName": "hello()"
+    },
+    {
+      "@id": "_:bnode5",
+      "@type": "kgrid:inputMessage",
+      "hasParams": "_:bnode1",
+      "noofparams": "2"
+    },
+    {
+      "@id": "http://example.com/UUID-0000-0000-0001",
+      "@type": "kgrid:knowledgeObject",
+      "hasInputMessage": "_:bnode5",
+      "hasOutputMessage": "_:bnode0",
+      "hasPayload": "_:bnode4",
+      "identifier": "ark:/1234/56somekobject"
+    }
+  ],
+  "@context": {
+    "returnType": {
+      "@id": "http://lhs.umich.edu/kgrid#returnType"
+    },
+    "_2": {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_2",
+      "@type": "@id"
+    },
+    "_1": {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1",
+      "@type": "@id"
+    },
+    "identifier": {
+      "@id": "http://schema.org/identifier"
+    },
+    "hasPayload": {
+      "@id": "http://lhs.umich.edu/kgrid#hasPayload",
+      "@type": "@id"
+    },
+    "hasOutputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasOutputMessage",
+      "@type": "@id"
+    },
+    "hasInputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasInputMessage",
+      "@type": "@id"
+    },
+    "engineType": {
+      "@id": "http://lhs.umich.edu/kgrid#engineType"
+    },
+    "content": {
+      "@id": "http://lhs.umich.edu/kgrid#content"
+    },
+    "functionName": {
+      "@id": "http://lhs.umich.edu/kgrid#functionName"
+    },
+    "datatype": {
+      "@id": "http://lhs.umich.edu/kgrid#datatype"
+    },
+    "paramname": {
+      "@id": "http://lhs.umich.edu/kgrid#paramname"
+    },
+    "hasParams": {
+      "@id": "http://lhs.umich.edu/kgrid#hasParams",
+      "@type": "@id"
+    },
+    "noofparams": {
+      "@id": "http://lhs.umich.edu/kgrid#noofparams"
+    },
+    "schema": "http://schema.org/",
+    "kgrid": "http://lhs.umich.edu/kgrid#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  }
+}

--- a/activator/src/test/resources/fixtures/kobject-sample.json
+++ b/activator/src/test/resources/fixtures/kobject-sample.json
@@ -1,87 +1,89 @@
 {
-  "@graph" : [ {
-    "@id" : "http://example.com/UUID-0000-0000-0001",
-    "@type" : "kgrid:knowledgeObject",
-    "hasInputMessage" : {
-      "@type" : "kgrid:inputMessage",
-      "hasParams" : {
-        "@type" : "rdf:Seq",
-        "_1" : {
-          "@type" : "kgrid:parameter",
-          "datatype" : "INT",
-          "paramname" : "bar"
+  "@graph": [
+    {
+      "@id": "http://example.com/UUID-0000-0000-0001",
+      "@type": "kgrid:knowledgeObject",
+      "hasInputMessage": {
+        "@type": "kgrid:inputMessage",
+        "hasParams": {
+          "@type": "rdf:Seq",
+          "_1": {
+            "@type": "kgrid:parameter",
+            "datatype": "INT",
+            "paramname": "bar"
+          },
+          "_2": {
+            "@type": "kgrid:parameter",
+            "datatype": "STRING",
+            "paramname": "foo"
+          }
         },
-        "_2" : {
-          "@type" : "kgrid:parameter",
-          "datatype" : "STRING",
-          "paramname" : "foo"
-        }
+        "noofparams": "2"
       },
-      "noofparams" : "2"
+      "hasOutputMessage": {
+        "@type": "kgrid:outputMessage",
+        "returnType": "MAP"
+      },
+      "hasPayload": {
+        "@type": "kgrid:payload",
+        "content": "def perform(params):\n          return  {'Hello': 'World'}\n        ",
+        "engineType": "Python",
+        "functionName": "hello()"
+      },
+      "identifier": "ark:/1234/56somekobject"
+    }
+  ],
+  "@context": {
+    "_2": {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_2",
+      "@type": "@id"
     },
-    "hasOutputMessage" : {
-      "@type" : "kgrid:outputMessage",
-      "returnType" : "MAP"
+    "_1": {
+      "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1",
+      "@type": "@id"
     },
-    "hasPayload" : {
-      "@type" : "kgrid:payload",
-      "content" : "def perform(params):\n          return  {'Hello': 'World'}\n        ",
-      "engineType" : "Python",
-      "functionName" : "hello()"
+    "identifier": {
+      "@id": "http://schema.org/identifier"
     },
-    "identifier" : "ark:/1234/56somekobject"
-  } ],
-  "@context" : {
-    "_2" : {
-      "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#_2",
-      "@type" : "@id"
+    "hasPayload": {
+      "@id": "http://lhs.umich.edu/kgrid#hasPayload",
+      "@type": "@id"
     },
-    "_1" : {
-      "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#_1",
-      "@type" : "@id"
+    "hasOutputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasOutputMessage",
+      "@type": "@id"
     },
-    "identifier" : {
-      "@id" : "http://schema.org/identifier"
+    "hasInputMessage": {
+      "@id": "http://lhs.umich.edu/kgrid#hasInputMessage",
+      "@type": "@id"
     },
-    "hasPayload" : {
-      "@id" : "http://lhs.umich.edu/kgrid#hasPayload",
-      "@type" : "@id"
+    "returnType": {
+      "@id": "http://lhs.umich.edu/kgrid#returnType"
     },
-    "hasOutputMessage" : {
-      "@id" : "http://lhs.umich.edu/kgrid#hasOutputMessage",
-      "@type" : "@id"
+    "datatype": {
+      "@id": "http://lhs.umich.edu/kgrid#datatype"
     },
-    "hasInputMessage" : {
-      "@id" : "http://lhs.umich.edu/kgrid#hasInputMessage",
-      "@type" : "@id"
+    "paramname": {
+      "@id": "http://lhs.umich.edu/kgrid#paramname"
     },
-    "returnType" : {
-      "@id" : "http://lhs.umich.edu/kgrid#returnType"
+    "hasParams": {
+      "@id": "http://lhs.umich.edu/kgrid#hasParams",
+      "@type": "@id"
     },
-    "datatype" : {
-      "@id" : "http://lhs.umich.edu/kgrid#datatype"
+    "noofparams": {
+      "@id": "http://lhs.umich.edu/kgrid#noofparams"
     },
-    "paramname" : {
-      "@id" : "http://lhs.umich.edu/kgrid#paramname"
+    "engineType": {
+      "@id": "http://lhs.umich.edu/kgrid#engineType"
     },
-    "hasParams" : {
-      "@id" : "http://lhs.umich.edu/kgrid#hasParams",
-      "@type" : "@id"
+    "content": {
+      "@id": "http://lhs.umich.edu/kgrid#content"
     },
-    "noofparams" : {
-      "@id" : "http://lhs.umich.edu/kgrid#noofparams"
+    "functionName": {
+      "@id": "http://lhs.umich.edu/kgrid#functionName"
     },
-    "engineType" : {
-      "@id" : "http://lhs.umich.edu/kgrid#engineType"
-    },
-    "content" : {
-      "@id" : "http://lhs.umich.edu/kgrid#content"
-    },
-    "functionName" : {
-      "@id" : "http://lhs.umich.edu/kgrid#functionName"
-    },
-    "schema" : "http://schema.org/",
-    "kgrid" : "http://lhs.umich.edu/kgrid#",
-    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    "schema": "http://schema.org/",
+    "kgrid": "http://lhs.umich.edu/kgrid#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   }
 }

--- a/activator/src/test/resources/fixtures/kobject-sample.xml
+++ b/activator/src/test/resources/fixtures/kobject-sample.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+  xmlns:kgrid="http://lhs.umich.edu/kgrid#"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:schema="http://schema.org/"
+>
+
+  <rdf:Description rdf:about="http://example.com/UUID-0000-0000-0001">
+    <!-- UUID of the knowledge object could be an ARK or DOI as well -->
+    <rdf:type rdf:resource="http://lhs.umich.edu/kgrid#knowledgeObject"/>
+    <kgrid:hasInputMessage rdf:nodeID="bnode01"/>
+    <kgrid:hasOutputMessage rdf:nodeID="bnode02"/>
+    <kgrid:hasPayload rdf:nodeID="bnode03"/>
+    <schema:identifier>ark:/1234/56somekobject</schema:identifier>
+  </rdf:Description>
+
+  <rdf:Description rdf:nodeID="bnode01">
+    <rdf:type rdf:resource="http://lhs.umich.edu/kgrid#inputMessage"/>
+    <kgrid:noofparams>2</kgrid:noofparams>
+    <kgrid:hasParams>
+      <rdf:Seq>
+        <rdf:li rdf:nodeID="bnode04"/>
+        <rdf:li rdf:nodeID="bnode05"/>
+      </rdf:Seq>
+    </kgrid:hasParams>
+  </rdf:Description>
+
+  <rdf:Description rdf:nodeID="bnode02">
+    <rdf:type rdf:resource="http://lhs.umich.edu/kgrid#outputMessage"/>
+    <kgrid:returnType>MAP</kgrid:returnType>
+  </rdf:Description>
+
+  <rdf:Description rdf:nodeID="bnode03">
+    <rdf:type rdf:resource="http://lhs.umich.edu/kgrid#payload"/>
+    <kgrid:functionName>hello()</kgrid:functionName>
+    <kgrid:content>def perform(params):
+    return  {'Hello': 'World'}
+</kgrid:content>
+    <kgrid:engineType>Python</kgrid:engineType>
+  </rdf:Description>
+
+  <rdf:Description rdf:nodeID="bnode04">
+    <rdf:type rdf:resource="http://lhs.umich.edu/kgrid#parameter"/>
+    <kgrid:paramname>foo</kgrid:paramname>
+    <kgrid:datatype>STRING</kgrid:datatype>
+  </rdf:Description>
+
+  <rdf:Description rdf:nodeID="bnode05">
+    <rdf:type rdf:resource="http://lhs.umich.edu/kgrid#parameter"/>
+    <kgrid:paramname>bar</kgrid:paramname>
+    <kgrid:datatype>INT</kgrid:datatype>
+  </rdf:Description>
+
+</rdf:RDF>

--- a/activator/src/test/resources/fixtures/kobject-sample.xml
+++ b/activator/src/test/resources/fixtures/kobject-sample.xml
@@ -34,8 +34,8 @@
     <rdf:type rdf:resource="http://lhs.umich.edu/kgrid#payload"/>
     <kgrid:functionName>hello()</kgrid:functionName>
     <kgrid:content>def perform(params):
-    return  {'Hello': 'World'}
-</kgrid:content>
+      return {'Hello': 'World'}
+    </kgrid:content>
     <kgrid:engineType>Python</kgrid:engineType>
   </rdf:Description>
 

--- a/activator/src/test/resources/fixtures/kobject-schema.xml
+++ b/activator/src/test/resources/fixtures/kobject-schema.xml
@@ -3,8 +3,6 @@
 <rdf:RDF
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://schema.org/version/latest/schema.rdf"
 >
   <!-- CLASSES -->
   <rdfs:Description rdf:about="http://lhs.umich.edu/kgrid#knoweldgeObject">

--- a/activator/src/test/resources/fixtures/kobject-schema.xml
+++ b/activator/src/test/resources/fixtures/kobject-schema.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Putative and minimal schemal for kgrid knowledge objects -->
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://schema.org/version/latest/schema.rdf"
+>
+  <!-- CLASSES -->
+  <rdfs:Description rdf:about="http://lhs.umich.edu/kgrid#knoweldgeObject">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdf:label>knowledgeObject</rdf:label>
+    <rdf:comment>A KGrid Knowledge Object</rdf:comment>
+  </rdfs:Description>
+
+  <rdf:Description rdf:about="http://lhs.umich.edu/kgrid#inputMessage">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdf:label>inputMessage</rdf:label>
+    <rdf:comment>An input specification of a knowledge object</rdf:comment>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://lhs.umich.edu/kgrid#outputMessage">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdf:label>outputMessage</rdf:label>
+    <rdf:comment>An output specification of a knowledge object.</rdf:comment>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://lhs.umich.edu/kgrid#parameter">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdf:label>parameter</rdf:label>
+    <rdf:comment>A parameter of an input message.</rdf:comment>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://lhs.umich.edu/kgrid#payload">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdf:label>payload</rdf:label>
+    <rdf:comment>The payload of a knowledge object.</rdf:comment>
+  </rdf:Description>
+
+  <!-- PROPERTIES -->
+  <rdf:Description rdf:about="http://lhs.umich.edu/kgrid#hasInputMessage">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Property"/>
+    <rdf:domain rdf:resource="http://lhs.umich.edu/kgrid#knoweldgeObject"/>
+    <rdf:range rdf:resource="http://lhs.umich.edu/kgrid#inputMessage"/>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://lhs.umich.edu/kgrid#hasOutputMessage">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Property"/>
+    <rdf:domain rdf:resource="http://lhs.umich.edu/kgrid#knoweldgeObject"/>
+    <rdf:range rdf:resource="http://lhs.umich.edu/kgrid#outputMessage"/>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://lhs.umich.edu/kgrid#hasPayload">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Property"/>
+    <rdf:domain rdf:resource="http://lhs.umich.edu/kgrid#knoweldgeObject"/>
+    <rdf:range rdf:resource="http://lhs.umich.edu/kgrid#payload"/>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://lhs.umich.edu/kgrid#noofparams">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Property"/>
+    <rdf:domain rdf:resource="http://lhs.umich.edu/kgrid#inputMessage"/>
+    <rdf:range rdf:resource=""/>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://lhs.umich.edu/kgrid#hasParams">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Property"/>
+    <rdf:domain rdf:resource="http://lhs.umich.edu/kgrid#inputMessage"/>
+    <rdf:range rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"/>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://lhs.umich.edu/kgrid#content">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Property"/>
+    <rdf:domain rdf:resource="http://lhs.umich.edu/kgrid#payload"/>
+    <rdf:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://lhs.umich.edu/kgrid#functionName">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Property"/>
+    <rdf:domain rdf:resource="http://lhs.umich.edu/kgrid#payload"/>
+    <rdf:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://lhs.umich.edu/kgrid#engineType">
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Property"/>
+    <rdf:domain rdf:resource="http://lhs.umich.edu/kgrid#payload"/>
+    <rdf:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+  </rdf:Description>
+
+
+</rdf:RDF>
+


### PR DESCRIPTION
Creating this PR prior to fully completing the implementation to solicit comments and questions about it.

Begins to address #41 

- Implements a Kobject class as the object that a json-ld knowledge object gets deserialized to.
- Implements PayloadProvider interface as partial replacement for IOSpec.
- Implements PayloadProviderValidator to check that an object actually provides the required parts of a payload.
- Adds a few serializations of knowledge objects to serve as test fixtures and examples.

Work to be done:
- Implement a PayloadInputValidator to validate an input to a knowledge object payload at runtime.
- Replace IOSpec usages with Kobject.
- Write tests and implementation to handle malformed or lacking kobject json-ld passed in.
- Internal default context to associate with kgrid schema uri if given a context URI that is not resolveable to a json-ld context.  i.e. http://lhs.umich.edu/kgrid.jsonld

