### PR TITLE
Generate the endpoint ID from the ark id of the KO

### DIFF
--- a/src/main/java/org/kgrid/activator/domain/Endpoint.java
+++ b/src/main/java/org/kgrid/activator/domain/Endpoint.java
@@ -23,12 +23,14 @@ public class Endpoint implements Comparable<Endpoint> {
     private String endpointName;
     private String detail;
     private URI physicalLocation;
+    private ArkId arkId;
 
     public Endpoint(KnowledgeObjectWrapper wrapper, String endpointName) {
         this.wrapper = wrapper;
         this.status = EndpointStatus.LOADED.name();
         this.endpointName = endpointName;
         this.activated = LocalDateTime.now();
+        this.arkId = getArkId();
     }
 
     public Endpoint(KnowledgeObjectWrapper wrapper, String endpointName, URI physicalLocation) {
@@ -37,6 +39,7 @@ public class Endpoint implements Comparable<Endpoint> {
         this.endpointName = endpointName;
         this.activated = LocalDateTime.now();
         this.physicalLocation = physicalLocation;
+        this.arkId = getArkId();
     }
 
     public String getEngine() {
@@ -115,18 +118,17 @@ public class Endpoint implements Comparable<Endpoint> {
     }
 
     public String getNaan() {
-        return wrapper.getMetadata().at("/@id").asText().split("/")[0];
+        return this.arkId.getNaan();
     }
 
-    public String getName() {
-        return wrapper.getMetadata().at("/@id").asText().split("/")[1];
-    }
+    public String getName() { return this.arkId.getName(); }
 
     public String getApiVersion() {
         return wrapper.getService().at("/info/version").asText();
     }
 
     public URI getId() {
+
         return URI.create(String.format("%s/%s/%s/%s", getNaan(), getName(), getApiVersion(), endpointName));
     }
 

--- a/src/test/java/org/kgrid/activator/services/KoValidationServiceTest.java
+++ b/src/test/java/org/kgrid/activator/services/KoValidationServiceTest.java
@@ -177,7 +177,10 @@ public class KoValidationServiceTest {
     }
 
     private KnowledgeObjectWrapper getWrapper(JsonNode serviceSpec, JsonNode deploymentSpec) {
-        JsonNode metadata = objectMapper.createObjectNode().put("@id", "naan/name/version").put("hasServiceSpecification", "value")
+        JsonNode metadata = objectMapper.createObjectNode()
+                .put("identifier", "ark:/naan/name/version")
+                .put("@id","naan/name/version")
+                .put("hasServiceSpecification", "value")
                 .put("hasDeploymentSpecification", "value");
         KnowledgeObjectWrapper wrapper = new KnowledgeObjectWrapper(metadata);
         wrapper.addDeployment(deploymentSpec);

--- a/src/test/java/org/kgrid/activator/testUtilities/KoCreationTestHelper.java
+++ b/src/test/java/org/kgrid/activator/testUtilities/KoCreationTestHelper.java
@@ -27,10 +27,10 @@ public class KoCreationTestHelper {
     public static final ArkId JS_ARK_ID = new ArkId(JS_NAAN, JS_NAME, JS_VERSION);
     public static final String JS_ENGINE = "javascript";
 
-    public static final String NODE_NAAN = "node-naan";
-    public static final String NODE_NAME = "node-name";
-    public static final String NODE_VERSION = "node-version";
-    public static final String NODE_ENDPOINT_NAME = "node-endpoint";
+    public static final String NODE_NAAN = "node_naan";
+    public static final String NODE_NAME = "node_name";
+    public static final String NODE_VERSION = "node_version";
+    public static final String NODE_ENDPOINT_NAME = "node_endpoint";
     public static final String NODE_API_VERSION = "nodeApiVersion";
     public static final String NODE_ENDPOINT_ID = String.format("%s/%s/%s/%s", NODE_NAAN, NODE_NAME, NODE_API_VERSION, NODE_ENDPOINT_NAME);
     public static final URI NODE_ENDPOINT_URI = URI.create(NODE_ENDPOINT_ID);


### PR DESCRIPTION
Update the getid() method in Endpoint class to use the arkId from met…adata field of `identifier` instead of `@id`; Update the tests to include `identifier` in the test wrapper.